### PR TITLE
Remove the PendingSubmission property from Imposter

### DIFF
--- a/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
@@ -37,13 +37,6 @@ namespace MbDotNet.Tests.Imposters
         }
 
         [TestMethod]
-        public void Constructor_PendingSubmissionUponCreation()
-        {
-            var imposter = new HttpImposter(123, null);
-            Assert.IsTrue(imposter.PendingSubmission);
-        }
-
-        [TestMethod]
         public void Constructor_InitializesStubsCollection()
         {
             var imposter = new HttpImposter(123, null);

--- a/MbDotNet.Tests/Models/Imposters/TcpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/TcpImposterTests.cs
@@ -47,13 +47,6 @@ namespace MbDotNet.Tests.Models.Imposters
         }
 
         [TestMethod]
-        public void Constructor_PendingSubmissionUponCreation()
-        {
-            var imposter = new TcpImposter(123, null, TcpMode.Text);
-            Assert.IsTrue(imposter.PendingSubmission);
-        }
-
-        [TestMethod]
         public void Constructor_InitializesStubsCollection()
         {
             var imposter = new TcpImposter(123, null, TcpMode.Text);

--- a/MbDotNet.Tests/MountebankClientTests.cs
+++ b/MbDotNet.Tests/MountebankClientTests.cs
@@ -120,26 +120,6 @@ namespace MbDotNet.Tests
         }
 
         [TestMethod]
-        public void Submit_SetsPendingSubmissionFalse()
-        {
-            var imposter = new HttpImposter(8080, null);
-
-            _client.Submit(imposter);
-
-            Assert.IsFalse(_client.Imposters.First().PendingSubmission);
-        }
-
-        [TestMethod]
-        public void Submit_DoesNotSubmitNonPendingImposters()
-        {
-            var imposter = new HttpImposter(123, null) {PendingSubmission = false};
-
-            _client.Submit(imposter);
-
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.IsAny<HttpImposter>()), Times.Never);
-        }
-
-        [TestMethod]
         public void DeleteImposter_CallsDelete()
         {
             const int port = 8080;
@@ -219,30 +199,6 @@ namespace MbDotNet.Tests
 
             Assert.AreEqual(1, _client.Imposters.Count(x => x.Port == firstPortNumber));
             Assert.AreEqual(1, _client.Imposters.Count(x => x.Port == secondPortNumber));
-        }
-
-        [TestMethod]
-        public void SubmitCollection_WhenImposterIsNotPending_ShouldNotSubmitImposter()
-        {
-            var imposter1 = _client.CreateHttpImposter(123);
-
-            imposter1.PendingSubmission = false;
-
-            _client.Submit(new[] { imposter1 });
-
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.IsAny<Imposter>()), Times.Never);
-        }
-
-        [TestMethod]
-        public void SubmitCollection_WhenImposterIsNotPending_ShouldNotAddToCollection()
-        {
-            var imposter1 = _client.CreateHttpImposter(123);
-
-            imposter1.PendingSubmission = false;
-
-            _client.Submit(new[] { imposter1 });
-
-            Assert.AreEqual(0, _client.Imposters.Count(x => x.Port == 123));
         }
     }
 }

--- a/MbDotNet/Models/Imposters/Imposter.cs
+++ b/MbDotNet/Models/Imposters/Imposter.cs
@@ -25,19 +25,12 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("name")]
         public string Name { get; private set; }
 
-        /// <summary>
-        /// Whether or not the imposter has been added to mountebank.
-        /// </summary>
-        [JsonIgnore]
-        public bool PendingSubmission { get; set; }
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Set as virtual for testing purposes")]
         public Imposter(int port, Protocol protocol, string name)
         {
             Port = port;
             Protocol = protocol.ToString().ToLower();
             Name = name;
-            PendingSubmission = true;
         }
     }
 }

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -85,10 +85,9 @@ namespace MbDotNet
         /// </summary>
         public void Submit(ICollection<Imposter> imposters)
         {
-            foreach (var imposter in imposters.Where(imp => imp.PendingSubmission))
+            foreach (var imposter in imposters)
             {
                 _requestProxy.CreateImposter(imposter);
-                imposter.PendingSubmission = false;
                 Imposters.Add(imposter);
             }
         }


### PR DESCRIPTION
Removed the PendingSubmission property from the Imposter model. With recent changes to the client API, it is no longer adding any value. Since you must explicitly submit each imposter, there is no point to keeping track of which ones are still pending submission.

Closes #12 