### PR TITLE
Add https imposter support

### DIFF
--- a/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
@@ -9,5 +9,6 @@ namespace MbDotNet.Acceptance.Tests
         public static void CanGetImposter(MountebankClient client) => new CanGetImposter(client).Run();
         public static void CanNotGetImposterThatDoesNotExist(MountebankClient client) => new CanNotGetImposterThatDoesNotExist(client).Run();
         public static void CanVerifyCallsOnImposter(MountebankClient client) => new CanVerifyCallsOnImposter(client).Run();
+        public static void CanCreateHttpsImposter(MountebankClient client) => new CanCreateHttpsImposter(client).Run();
     }
 }

--- a/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
@@ -4,7 +4,7 @@ namespace MbDotNet.Acceptance.Tests
 {
     internal static class AcceptanceTest
     {
-        public static void CanCreateImposter(MountebankClient client) => new CanCreateImposterTest(client).Run();
+        public static void CanCreateImposter(MountebankClient client) => new CanCreateImposter(client).Run();
         public static void CanDeleteImposter(MountebankClient client) => new CanDeleteImposter(client).Run();
         public static void CanGetImposter(MountebankClient client) => new CanGetImposter(client).Run();
         public static void CanNotGetImposterThatDoesNotExist(MountebankClient client) => new CanNotGetImposterThatDoesNotExist(client).Run();

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateHttpsImposter.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateHttpsImposter.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+
+namespace MbDotNet.Acceptance.Tests.AcceptanceTests
+{
+    internal class CanCreateHttpsImposter
+    {
+        private readonly MountebankClient _client;
+        const int ImposterPort = 6000;
+
+        public CanCreateHttpsImposter(MountebankClient client)
+        {
+            this._client = client;
+        }
+
+        public void Run()
+        {
+            DeleteAllImposters();
+            CreateImposter();
+            VerifyImposterHasBeenCreated();
+            DeleteAllImposters();
+        }
+
+        private void DeleteAllImposters()
+        {
+            _client.DeleteAllImposters();
+        }
+
+        private void VerifyImposterHasBeenCreated()
+        {
+            var imposter = _client.GetImposter(ImposterPort);
+            imposter.Should().NotBeNull();
+        }
+
+        private void CreateImposter()
+        {
+            var imposter = _client.CreateHttpsImposter(ImposterPort);
+            _client.Submit(imposter);
+        }
+    }
+}

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateImposter.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateImposter.cs
@@ -2,12 +2,12 @@ using FluentAssertions;
 
 namespace MbDotNet.Acceptance.Tests.AcceptanceTests
 {
-    internal class CanCreateImposterTest
+    internal class CanCreateImposter
     {
         private readonly MountebankClient _client;
         const int ImposterPort = 6000;
 
-        public CanCreateImposterTest(MountebankClient client)
+        public CanCreateImposter(MountebankClient client)
         {
             _client = client;
             

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateImposterTest.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateImposterTest.cs
@@ -1,6 +1,4 @@
-using System.Net;
 using FluentAssertions;
-using MbDotNet.Exceptions;
 
 namespace MbDotNet.Acceptance.Tests.AcceptanceTests
 {

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanDeleteImposter.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanDeleteImposter.cs
@@ -1,7 +1,5 @@
-﻿using System.Net;
 using FluentAssertions;
 using MbDotNet.Exceptions;
-using MbDotNet.Models.Imposters;
 
 namespace MbDotNet.Acceptance.Tests.AcceptanceTests
 {

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanVerifyCallsOnImposter.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanVerifyCallsOnImposter.cs
@@ -13,9 +13,7 @@ namespace MbDotNet.Acceptance.Tests.AcceptanceTests
         private HttpImposter _imposter;
         private RetrievedImposter _retrievedImposter;
         const int ImposterPort = 6000;
-
-       
-
+        
         public CanVerifyCallsOnImposter(MountebankClient client)
         {
             _client = client;

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanVerifyCallsOnImposter.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanVerifyCallsOnImposter.cs
@@ -32,6 +32,9 @@ namespace MbDotNet.Acceptance.Tests.AcceptanceTests
             _retrievedImposter = _client.GetImposter(ImposterPort);
 
             _retrievedImposter.NumberOfRequests.Should().Be(1);
+            
+            // For the request field to be populated, mountebank must be run with the --mock parameter
+            // http://www.mbtest.org/docs/api/overview#get-imposter
             var receivedRequest = _retrievedImposter.Requests[0];
 
             receivedRequest.Path.Should().Be("/customers");

--- a/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
+++ b/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+    <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MbDotNet\MbDotNet.csproj">

--- a/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
+++ b/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AcceptanceTest.cs" />
-    <Compile Include="AcceptanceTests\CanCreateImposterTest.cs" />
+    <Compile Include="AcceptanceTests\CanCreateImposter.cs" />
     <Compile Include="AcceptanceTests\CanDeleteImposter.cs" />
     <Compile Include="AcceptanceTests\CanGetImposter.cs" />
     <Compile Include="AcceptanceTests\CanNotGetImposterThatDoesNotExist.cs" />

--- a/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
+++ b/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="AcceptanceTests\CanGetImposter.cs" />
     <Compile Include="AcceptanceTests\CanNotGetImposterThatDoesNotExist.cs" />
     <Compile Include="AcceptanceTests\CanVerifyCallsOnImposter.cs" />
+    <Compile Include="AcceptanceTests\CanCreateHttpsImposter.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MbDotNet.Acceptance.Tests/Program.cs
+++ b/MbDotNet.Acceptance.Tests/Program.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MbDotNet.Acceptance.Tests
 {

--- a/MbDotNet.Acceptance.Tests/Program.cs
+++ b/MbDotNet.Acceptance.Tests/Program.cs
@@ -22,6 +22,7 @@ namespace MbDotNet.Acceptance.Tests
                 AcceptanceTest.CanGetImposter(Client);
                 AcceptanceTest.CanNotGetImposterThatDoesNotExist(Client);
                 AcceptanceTest.CanCreateImposter(Client);
+                AcceptanceTest.CanCreateHttpsImposter(Client);
                 AcceptanceTest.CanDeleteImposter(Client);
                 AcceptanceTest.CanVerifyCallsOnImposter(Client);
             }

--- a/MbDotNet.Acceptance.Tests/README.md
+++ b/MbDotNet.Acceptance.Tests/README.md
@@ -1,0 +1,3 @@
+﻿# Running Acceptance tests
+- Please run an instance of mountebank on the default localhost and port to run these tests against
+- Mountebank should be run with the --mock option enabled in order for the imposter request field to be populated. See http://www.mbtest.org/docs/api/overview#get-imposter.

--- a/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
@@ -1,0 +1,49 @@
+using MbDotNet.Interfaces;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace MbDotNet.Tests.Client
+{
+    [TestClass]
+    public class CreateHttpImposterTests
+    {
+        private IClient _client;
+        private Mock<IRequestProxy> _mockRequestProxy;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this._mockRequestProxy = new Mock<IRequestProxy>();
+            this._client = new MountebankClient(this._mockRequestProxy.Object);
+        }
+
+        [TestMethod]
+        public void CreateHttpImposter_ShouldNotAddNewImposterToCollection()
+        {
+            _client.CreateHttpImposter(123);
+            Assert.AreEqual(0, _client.Imposters.Count);
+        }
+        
+        [TestMethod]
+        public void CreateHttpImposter_WithoutName_SetsNameToNull()
+        {
+            var imposter = _client.CreateHttpImposter(123);
+            
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Name);
+        }
+
+        [TestMethod]
+        public void CreateHttpImposter_WithName_SetsName()
+        {
+            const string expectedName = "Service";
+
+            var imposter = _client.CreateHttpImposter(123, expectedName);
+            
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedName, imposter.Name);
+        }
+    }
+}

--- a/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
@@ -1,24 +1,10 @@
-using MbDotNet.Interfaces;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Moq;
 
 namespace MbDotNet.Tests.Client
 {
     [TestClass]
-    public class CreateHttpImposterTests
+    public class CreateHttpImposterTests : MountebankClientTestBase
     {
-        private IClient _client;
-        private Mock<IRequestProxy> _mockRequestProxy;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            this._mockRequestProxy = new Mock<IRequestProxy>();
-            this._client = new MountebankClient(this._mockRequestProxy.Object);
-        }
-
         [TestMethod]
         public void CreateHttpImposter_ShouldNotAddNewImposterToCollection()
         {

--- a/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MbDotNet.Tests.Client
+{
+    [TestClass]
+    public class CreateHttpsImposterTests : MountebankClientTestBase
+    {
+        [TestMethod]
+        public void CreateHttpsImposter_ShouldNotAddNewImposterToCollection()
+        {
+            _client.CreateHttpsImposter(123);
+            Assert.AreEqual(0, _client.Imposters.Count);
+        }
+        
+        [TestMethod]
+        public void CreateHttpsImposter_WithoutName_SetsNameToNull()
+        {
+            var imposter = _client.CreateHttpsImposter(123);
+            
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Name);
+        }
+
+        [TestMethod]
+        public void CreateHttpsImposter_WithName_SetsName()
+        {
+            const string expectedName = "Service";
+
+            var imposter = _client.CreateHttpsImposter(123, expectedName);
+            
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedName, imposter.Name);
+        }
+
+        [TestMethod]
+        public void CreateHttpsImposter_WithKey_SetsKey()
+        {
+            const string expectedKey = "key";
+
+            var imposter = _client.CreateHttpsImposter(123, null, expectedKey);
+
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedKey, imposter.Key);
+        }
+
+        [TestMethod]
+        public void CreateHttpsImposter_WithCert_SetsCert()
+        {
+            const string expectedCert = "cert";
+
+            var imposter = _client.CreateHttpsImposter(123, null, null, expectedCert);
+
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedCert, imposter.Cert);
+        }
+    }
+}

--- a/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
@@ -1,25 +1,12 @@
 using MbDotNet.Enums;
-using MbDotNet.Interfaces;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Moq;
 
 namespace MbDotNet.Tests.Client
 {
     [TestClass]
-    public class CreateTcpImposterTests
+    public class CreateTcpImposterTests : MountebankClientTestBase
     {
-        private IClient _client;
-        private Mock<IRequestProxy> _mockRequestProxy;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            this._mockRequestProxy = new Mock<IRequestProxy>();
-            this._client = new MountebankClient(this._mockRequestProxy.Object);
-        }
-
         [TestMethod]
         public void CreateTcpImposter_WithoutName_SetsNameToNull()
         {

--- a/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
@@ -1,0 +1,65 @@
+using MbDotNet.Enums;
+using MbDotNet.Interfaces;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace MbDotNet.Tests.Client
+{
+    [TestClass]
+    public class CreateTcpImposterTests
+    {
+        private IClient _client;
+        private Mock<IRequestProxy> _mockRequestProxy;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this._mockRequestProxy = new Mock<IRequestProxy>();
+            this._client = new MountebankClient(this._mockRequestProxy.Object);
+        }
+
+        [TestMethod]
+        public void CreateTcpImposter_WithoutName_SetsNameToNull()
+        {
+            var imposter = _client.CreateTcpImposter(123);
+
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Name);
+        }
+
+        [TestMethod]
+        public void CreateTcpImposter_WithName_SetsName()
+        {
+            const string expectedName = "Service";
+
+            var imposter = _client.CreateTcpImposter(123, expectedName);
+            
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedName, imposter.Name);
+        }
+
+        [TestMethod]
+        public void CreateTcpImposter_WithoutMode_SetsModeToText()
+        {
+            const string expectedMode = "text";
+
+            var imposter = _client.CreateTcpImposter(123, null);
+            
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedMode, imposter.Mode);
+        }
+
+        [TestMethod]
+        public void CreateTcpImposter_WithMode_SetsMode()
+        {
+            const string expectedMode = "binary";
+
+            var imposter = _client.CreateTcpImposter(123, null, TcpMode.Binary);
+
+            Assert.IsNotNull(imposter);
+            Assert.AreEqual(expectedMode, imposter.Mode);
+        }
+    }
+}

--- a/MbDotNet.Tests/Client/DeleteImposterTests.cs
+++ b/MbDotNet.Tests/Client/DeleteImposterTests.cs
@@ -1,0 +1,75 @@
+using MbDotNet.Interfaces;
+using MbDotNet.Models.Imposters;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace MbDotNet.Tests.Client
+{
+    [TestClass]
+    public class DeleteImposterTests
+    {
+        private IClient _client;
+        private Mock<IRequestProxy> _mockRequestProxy;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this._mockRequestProxy = new Mock<IRequestProxy>();
+            this._client = new MountebankClient(this._mockRequestProxy.Object);
+        }
+
+        [TestMethod]
+        public void DeleteImposter_CallsDelete()
+        {
+            const int port = 8080;
+
+            _client.Imposters.Add(new HttpImposter(port, null));
+
+            _mockRequestProxy.Setup(x => x.DeleteImposter(port));
+
+            _client.DeleteImposter(port);
+
+            _mockRequestProxy.Verify(x => x.DeleteImposter(port), Times.Once);
+        }
+
+        [TestMethod]
+        public void DeleteImposter_RemovesImposterFromCollection()
+        {
+            const int port = 8080;
+
+            _client.Imposters.Add(new HttpImposter(port, null));
+
+            _client.DeleteImposter(port);
+
+            Assert.AreEqual(0, _client.Imposters.Count);
+        }
+
+        [TestMethod]
+        public void DeleteAllImposters_CallsDeleteAll()
+        {
+            _mockRequestProxy.Setup(x => x.DeleteAllImposters());
+
+            _client.Imposters.Add(new HttpImposter(123, null));
+            _client.Imposters.Add(new HttpImposter(456, null));
+
+            _client.DeleteAllImposters();
+
+            _mockRequestProxy.Verify(x => x.DeleteAllImposters(), Times.Once);
+        }
+
+        [TestMethod]
+        public void DeleteAllImposters_RemovesAllImpostersFromCollection()
+        {
+            _mockRequestProxy.Setup(x => x.DeleteAllImposters());
+
+            _client.Imposters.Add(new HttpImposter(123, null));
+            _client.Imposters.Add(new HttpImposter(456, null));
+
+            _client.DeleteAllImposters();
+
+            Assert.AreEqual(0, _client.Imposters.Count);
+        }
+    }
+}

--- a/MbDotNet.Tests/Client/DeleteImposterTests.cs
+++ b/MbDotNet.Tests/Client/DeleteImposterTests.cs
@@ -1,4 +1,3 @@
-using MbDotNet.Interfaces;
 using MbDotNet.Models.Imposters;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -8,18 +7,8 @@ using Moq;
 namespace MbDotNet.Tests.Client
 {
     [TestClass]
-    public class DeleteImposterTests
+    public class DeleteImposterTests : MountebankClientTestBase
     {
-        private IClient _client;
-        private Mock<IRequestProxy> _mockRequestProxy;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            this._mockRequestProxy = new Mock<IRequestProxy>();
-            this._client = new MountebankClient(this._mockRequestProxy.Object);
-        }
-
         [TestMethod]
         public void DeleteImposter_CallsDelete()
         {

--- a/MbDotNet.Tests/Client/MountebankClientTestBase.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTestBase.cs
@@ -1,0 +1,21 @@
+using MbDotNet.Interfaces;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace MbDotNet.Tests.Client
+{
+    public class MountebankClientTestBase
+    {
+        protected IClient _client;
+        internal Mock<IRequestProxy> _mockRequestProxy;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this._mockRequestProxy = new Mock<IRequestProxy>();
+            this._client = new MountebankClient(this._mockRequestProxy.Object);
+        }
+    }
+}

--- a/MbDotNet.Tests/Client/MountebankClientTests.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTests.cs
@@ -1,13 +1,17 @@
-﻿using System.Collections.Generic;
+﻿
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using MbDotNet.Enums;
 using MbDotNet.Interfaces;
 using MbDotNet.Models.Imposters;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Moq;
 
-namespace MbDotNet.Tests
+namespace MbDotNet.Tests.Client
 {
+
     [TestClass]
     public class MountebankClientTests
     {
@@ -17,8 +21,8 @@ namespace MbDotNet.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            _mockRequestProxy = new Mock<IRequestProxy>();
-            _client = new MountebankClient(_mockRequestProxy.Object);
+            this._mockRequestProxy = new Mock<IRequestProxy>();
+            this._client = new MountebankClient(this._mockRequestProxy.Object);
         }
 
         [TestMethod]
@@ -31,14 +35,14 @@ namespace MbDotNet.Tests
         [TestMethod]
         public void CreateHttpImposter_ShouldNotAddNewImposterToCollection()
         {
-            _client.CreateHttpImposter(123);
-            Assert.AreEqual(0, _client.Imposters.Count);
+            this._client.CreateHttpImposter(123);
+            Assert.AreEqual(0, this._client.Imposters.Count);
         }
 
         [TestMethod]
         public void CreateHttpImposter_WithoutName_SetsNameToNull()
         {
-            var imposter = _client.CreateHttpImposter(123);
+            var imposter = this._client.CreateHttpImposter(123);
             
             Assert.IsNotNull(imposter);
             Assert.IsNull(imposter.Name);
@@ -49,7 +53,7 @@ namespace MbDotNet.Tests
         {
             const string expectedName = "Service";
 
-            var imposter = _client.CreateHttpImposter(123, expectedName);
+            var imposter = this._client.CreateHttpImposter(123, expectedName);
             
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedName, imposter.Name);
@@ -58,14 +62,14 @@ namespace MbDotNet.Tests
         [TestMethod]
         public void CreateTcpImposter_ShouldNotAddNewImposterToCollection()
         {
-            _client.CreateTcpImposter(123);
-            Assert.AreEqual(0, _client.Imposters.Count);
+            this._client.CreateTcpImposter(123);
+            Assert.AreEqual(0, this._client.Imposters.Count);
         }
 
         [TestMethod]
         public void CreateTcpImposter_WithoutName_SetsNameToNull()
         {
-            var imposter = _client.CreateTcpImposter(123);
+            var imposter = this._client.CreateTcpImposter(123);
 
             Assert.IsNotNull(imposter);
             Assert.IsNull(imposter.Name);
@@ -76,7 +80,7 @@ namespace MbDotNet.Tests
         {
             const string expectedName = "Service";
 
-            var imposter = _client.CreateTcpImposter(123, expectedName);
+            var imposter = this._client.CreateTcpImposter(123, expectedName);
             
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedName, imposter.Name);
@@ -87,7 +91,7 @@ namespace MbDotNet.Tests
         {
             const string expectedMode = "text";
 
-            var imposter = _client.CreateTcpImposter(123, null);
+            var imposter = this._client.CreateTcpImposter(123, null);
             
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedMode, imposter.Mode);
@@ -98,7 +102,7 @@ namespace MbDotNet.Tests
         {
             const string expectedMode = "binary";
 
-            var imposter = _client.CreateTcpImposter(123, null, TcpMode.Binary);
+            var imposter = this._client.CreateTcpImposter(123, null, TcpMode.Binary);
 
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedMode, imposter.Mode);
@@ -113,10 +117,10 @@ namespace MbDotNet.Tests
             var imposter1 = new HttpImposter(firstPortNumber, null);
             var imposter2 = new HttpImposter(secondPortNumber, null);
           
-            _client.Submit(new [] { imposter1, imposter2});
+            this._client.Submit(new [] { imposter1, imposter2});
 
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == firstPortNumber)), Times.Once);
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == secondPortNumber)), Times.Once);
+            this._mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == firstPortNumber)), Times.Once);
+            this._mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == secondPortNumber)), Times.Once);
         }
 
         [TestMethod]
@@ -124,13 +128,13 @@ namespace MbDotNet.Tests
         {
             const int port = 8080;
 
-            _client.Imposters.Add(new HttpImposter(port, null));
+            this._client.Imposters.Add(new HttpImposter(port, null));
 
-            _mockRequestProxy.Setup(x => x.DeleteImposter(port));
+            this._mockRequestProxy.Setup(x => x.DeleteImposter(port));
 
-            _client.DeleteImposter(port);
+            this._client.DeleteImposter(port);
 
-            _mockRequestProxy.Verify(x => x.DeleteImposter(port), Times.Once);
+            this._mockRequestProxy.Verify(x => x.DeleteImposter(port), Times.Once);
         }
 
         [TestMethod]
@@ -138,37 +142,37 @@ namespace MbDotNet.Tests
         {
             const int port = 8080;
 
-            _client.Imposters.Add(new HttpImposter(port, null));
+            this._client.Imposters.Add(new HttpImposter(port, null));
 
-            _client.DeleteImposter(port);
+            this._client.DeleteImposter(port);
 
-            Assert.AreEqual(0, _client.Imposters.Count);
+            Assert.AreEqual(0, this._client.Imposters.Count);
         }
 
         [TestMethod]
         public void DeleteAllImposters_CallsDeleteAll()
         {
-            _mockRequestProxy.Setup(x => x.DeleteAllImposters());
+            this._mockRequestProxy.Setup(x => x.DeleteAllImposters());
 
-            _client.Imposters.Add(new HttpImposter(123, null));
-            _client.Imposters.Add(new HttpImposter(456, null));
+            this._client.Imposters.Add(new HttpImposter(123, null));
+            this._client.Imposters.Add(new HttpImposter(456, null));
 
-            _client.DeleteAllImposters();
+            this._client.DeleteAllImposters();
 
-            _mockRequestProxy.Verify(x => x.DeleteAllImposters(), Times.Once);
+            this._mockRequestProxy.Verify(x => x.DeleteAllImposters(), Times.Once);
         }
 
         [TestMethod]
         public void DeleteAllImposters_RemovesAllImpostersFromCollection()
         {
-            _mockRequestProxy.Setup(x => x.DeleteAllImposters());
+            this._mockRequestProxy.Setup(x => x.DeleteAllImposters());
 
-            _client.Imposters.Add(new HttpImposter(123, null));
-            _client.Imposters.Add(new HttpImposter(456, null));
+            this._client.Imposters.Add(new HttpImposter(123, null));
+            this._client.Imposters.Add(new HttpImposter(456, null));
 
-            _client.DeleteAllImposters();
+            this._client.DeleteAllImposters();
 
-            Assert.AreEqual(0, _client.Imposters.Count);
+            Assert.AreEqual(0, this._client.Imposters.Count);
         }
          
         [TestMethod]
@@ -177,13 +181,13 @@ namespace MbDotNet.Tests
             const int firstPortNumber = 123;
             const int secondPortNumber = 456;
 
-            var imposter1 = _client.CreateHttpImposter(firstPortNumber);
-            var imposter2 = _client.CreateHttpImposter(secondPortNumber);
+            var imposter1 = this._client.CreateHttpImposter(firstPortNumber);
+            var imposter2 = this._client.CreateHttpImposter(secondPortNumber);
             
-            _client.Submit(new[] { imposter1, imposter2 });
+            this._client.Submit(new[] { imposter1, imposter2 });
 
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == firstPortNumber)), Times.Once);
-            _mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == secondPortNumber)), Times.Once);
+            this._mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == firstPortNumber)), Times.Once);
+            this._mockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == secondPortNumber)), Times.Once);
         }
 
         [TestMethod]
@@ -192,13 +196,13 @@ namespace MbDotNet.Tests
             const int firstPortNumber = 123;
             const int secondPortNumber = 456;
 
-            var imposter1 = _client.CreateHttpImposter(firstPortNumber);
-            var imposter2 = _client.CreateHttpImposter(secondPortNumber);
+            var imposter1 = this._client.CreateHttpImposter(firstPortNumber);
+            var imposter2 = this._client.CreateHttpImposter(secondPortNumber);
 
-            _client.Submit(new[] { imposter1, imposter2 });
+            this._client.Submit(new[] { imposter1, imposter2 });
 
-            Assert.AreEqual(1, _client.Imposters.Count(x => x.Port == firstPortNumber));
-            Assert.AreEqual(1, _client.Imposters.Count(x => x.Port == secondPortNumber));
+            Assert.AreEqual(1, this._client.Imposters.Count(x => x.Port == firstPortNumber));
+            Assert.AreEqual(1, this._client.Imposters.Count(x => x.Port == secondPortNumber));
         }
     }
 }

--- a/MbDotNet.Tests/Client/MountebankClientTests.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTests.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Linq;
+﻿using System.Linq;
 
 using MbDotNet.Enums;
 using MbDotNet.Interfaces;
@@ -11,13 +10,12 @@ using Moq;
 
 namespace MbDotNet.Tests.Client
 {
-
     [TestClass]
     public class MountebankClientTests
     {
         private IClient _client;
         private Mock<IRequestProxy> _mockRequestProxy;
-
+        
         [TestInitialize]
         public void TestInitialize()
         {
@@ -30,33 +28,6 @@ namespace MbDotNet.Tests.Client
         {
             var client = new MountebankClient();
             Assert.IsNotNull(client.Imposters);
-        }
-
-        [TestMethod]
-        public void CreateHttpImposter_ShouldNotAddNewImposterToCollection()
-        {
-            this._client.CreateHttpImposter(123);
-            Assert.AreEqual(0, this._client.Imposters.Count);
-        }
-
-        [TestMethod]
-        public void CreateHttpImposter_WithoutName_SetsNameToNull()
-        {
-            var imposter = this._client.CreateHttpImposter(123);
-            
-            Assert.IsNotNull(imposter);
-            Assert.IsNull(imposter.Name);
-        }
-
-        [TestMethod]
-        public void CreateHttpImposter_WithName_SetsName()
-        {
-            const string expectedName = "Service";
-
-            var imposter = this._client.CreateHttpImposter(123, expectedName);
-            
-            Assert.IsNotNull(imposter);
-            Assert.AreEqual(expectedName, imposter.Name);
         }
 
         [TestMethod]

--- a/MbDotNet.Tests/Client/MountebankClientTests.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 
-using MbDotNet.Enums;
 using MbDotNet.Interfaces;
 using MbDotNet.Models.Imposters;
 
@@ -15,7 +14,7 @@ namespace MbDotNet.Tests.Client
     {
         private IClient _client;
         private Mock<IRequestProxy> _mockRequestProxy;
-        
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -35,48 +34,6 @@ namespace MbDotNet.Tests.Client
         {
             this._client.CreateTcpImposter(123);
             Assert.AreEqual(0, this._client.Imposters.Count);
-        }
-
-        [TestMethod]
-        public void CreateTcpImposter_WithoutName_SetsNameToNull()
-        {
-            var imposter = this._client.CreateTcpImposter(123);
-
-            Assert.IsNotNull(imposter);
-            Assert.IsNull(imposter.Name);
-        }
-
-        [TestMethod]
-        public void CreateTcpImposter_WithName_SetsName()
-        {
-            const string expectedName = "Service";
-
-            var imposter = this._client.CreateTcpImposter(123, expectedName);
-            
-            Assert.IsNotNull(imposter);
-            Assert.AreEqual(expectedName, imposter.Name);
-        }
-
-        [TestMethod]
-        public void CreateTcpImposter_WithoutMode_SetsModeToText()
-        {
-            const string expectedMode = "text";
-
-            var imposter = this._client.CreateTcpImposter(123, null);
-            
-            Assert.IsNotNull(imposter);
-            Assert.AreEqual(expectedMode, imposter.Mode);
-        }
-
-        [TestMethod]
-        public void CreateTcpImposter_WithMode_SetsMode()
-        {
-            const string expectedMode = "binary";
-
-            var imposter = this._client.CreateTcpImposter(123, null, TcpMode.Binary);
-
-            Assert.IsNotNull(imposter);
-            Assert.AreEqual(expectedMode, imposter.Mode);
         }
 
         [TestMethod]

--- a/MbDotNet.Tests/Client/MountebankClientTests.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 
-using MbDotNet.Interfaces;
 using MbDotNet.Models.Imposters;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -10,18 +9,8 @@ using Moq;
 namespace MbDotNet.Tests.Client
 {
     [TestClass]
-    public class MountebankClientTests
+    public class MountebankClientTests : MountebankClientTestBase
     {
-        private IClient _client;
-        private Mock<IRequestProxy> _mockRequestProxy;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            this._mockRequestProxy = new Mock<IRequestProxy>();
-            this._client = new MountebankClient(this._mockRequestProxy.Object);
-        }
-
         [TestMethod]
         public void Constructor_InitializesImposterCollection()
         {

--- a/MbDotNet.Tests/Client/MountebankClientTests.cs
+++ b/MbDotNet.Tests/Client/MountebankClientTests.cs
@@ -52,58 +52,6 @@ namespace MbDotNet.Tests.Client
         }
 
         [TestMethod]
-        public void DeleteImposter_CallsDelete()
-        {
-            const int port = 8080;
-
-            this._client.Imposters.Add(new HttpImposter(port, null));
-
-            this._mockRequestProxy.Setup(x => x.DeleteImposter(port));
-
-            this._client.DeleteImposter(port);
-
-            this._mockRequestProxy.Verify(x => x.DeleteImposter(port), Times.Once);
-        }
-
-        [TestMethod]
-        public void DeleteImposter_RemovesImposterFromCollection()
-        {
-            const int port = 8080;
-
-            this._client.Imposters.Add(new HttpImposter(port, null));
-
-            this._client.DeleteImposter(port);
-
-            Assert.AreEqual(0, this._client.Imposters.Count);
-        }
-
-        [TestMethod]
-        public void DeleteAllImposters_CallsDeleteAll()
-        {
-            this._mockRequestProxy.Setup(x => x.DeleteAllImposters());
-
-            this._client.Imposters.Add(new HttpImposter(123, null));
-            this._client.Imposters.Add(new HttpImposter(456, null));
-
-            this._client.DeleteAllImposters();
-
-            this._mockRequestProxy.Verify(x => x.DeleteAllImposters(), Times.Once);
-        }
-
-        [TestMethod]
-        public void DeleteAllImposters_RemovesAllImpostersFromCollection()
-        {
-            this._mockRequestProxy.Setup(x => x.DeleteAllImposters());
-
-            this._client.Imposters.Add(new HttpImposter(123, null));
-            this._client.Imposters.Add(new HttpImposter(456, null));
-
-            this._client.DeleteAllImposters();
-
-            Assert.AreEqual(0, this._client.Imposters.Count);
-        }
-         
-        [TestMethod]
         public void SubmitCollection_ShouldSubmitImpostersUsingProxy()
         {
             const int firstPortNumber = 123;

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Models\Responses\IsResponseTests.cs" />
     <Compile Include="Models\Stubs\HttpStubTests.cs" />
     <Compile Include="Models\Stubs\TcpStubTests.cs" />
-    <Compile Include="MountebankClientTests.cs" />
+    <Compile Include="Client\MountebankClientTests.cs" />
     <Compile Include="MountebankRequestProxyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TutorialExamples.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Client\CreateHttpImposterTests.cs" />
     <Compile Include="Client\CreateTcpImposterTests.cs" />
     <Compile Include="Client\DeleteImposterTests.cs" />
+    <Compile Include="Client\MountebankClientTestBase.cs" />
     <Compile Include="Models\Imposters\HttpsImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpImposterTests.cs" />
     <Compile Include="Models\Imposters\TcpImposterTests.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -66,6 +66,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Client\CreateHttpImposterTests.cs" />
+    <Compile Include="Client\CreateHttpsImposterTests.cs" />
     <Compile Include="Client\CreateTcpImposterTests.cs" />
     <Compile Include="Client\DeleteImposterTests.cs" />
     <Compile Include="Client\MountebankClientTestBase.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -65,6 +65,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Models\Imposters\HttpsImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpImposterTests.cs" />
     <Compile Include="Models\Imposters\TcpImposterTests.cs" />
     <Compile Include="Models\Predicates\ContainsPredicateTests.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <Compile Include="Client\CreateHttpImposterTests.cs" />
     <Compile Include="Client\CreateTcpImposterTests.cs" />
+    <Compile Include="Client\DeleteImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpsImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpImposterTests.cs" />
     <Compile Include="Models\Imposters\TcpImposterTests.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -65,6 +65,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Client\CreateHttpImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpsImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpImposterTests.cs" />
     <Compile Include="Models\Imposters\TcpImposterTests.cs" />

--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -66,6 +66,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Client\CreateHttpImposterTests.cs" />
+    <Compile Include="Client\CreateTcpImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpsImposterTests.cs" />
     <Compile Include="Models\Imposters\HttpImposterTests.cs" />
     <Compile Include="Models\Imposters\TcpImposterTests.cs" />

--- a/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
@@ -54,7 +54,7 @@ namespace MbDotNet.Tests.Imposters
             imposter.AddStub();
             Assert.AreEqual(1, imposter.Stubs.Count);
         }
-
+                
         #endregion
     }
 }

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -47,7 +47,7 @@ namespace MbDotNet.Tests.Imposters
         public void Constructor_SetsKey()
         {
             var testKeyValue = "testKey";
-            var imposter = new HttpsImposter(123, null, testKeyValue);
+            var imposter = new HttpsImposter(123, null, testKeyValue, null);
             Assert.AreEqual(imposter.Key, testKeyValue);
         }
 
@@ -56,6 +56,14 @@ namespace MbDotNet.Tests.Imposters
         {
             var imposter = new HttpsImposter(123, null);
             Assert.IsNull(imposter.Key);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsCert()
+        {
+            var testCertValue = "testCert";
+            var imposter = new HttpsImposter(123, null, null, testCertValue);
+            Assert.AreEqual(imposter.Cert, testCertValue);
         }
 
         #endregion

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -51,6 +51,13 @@ namespace MbDotNet.Tests.Imposters
             Assert.AreEqual(imposter.Key, testKeyValue);
         }
 
+        [TestMethod]
+        public void Constructor_SetsKeyAsNullWhenMissing()
+        {
+            var imposter = new HttpsImposter(123, null);
+            Assert.IsNull(imposter.Key);
+        }
+
         #endregion
 
         #region Stub Tests

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MbDotNet.Enums;
+using MbDotNet.Models;
+using MbDotNet.Models.Imposters;
+
+namespace MbDotNet.Tests.Imposters
+{
+    /// <summary>
+    /// Summary description for ImposterTests
+    /// </summary>
+    [TestClass]
+    public class HttpsImposterTests
+    {
+        #region Constructor Tests
+
+        [TestMethod]
+        public void Constructor_SetsPort()
+        {
+            const int port = 123;
+            var imposter = new HttpsImposter(port, null);
+            Assert.AreEqual(port, imposter.Port);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsProtocol()
+        {
+            var imposter = new HttpsImposter(123, null);
+            Assert.AreEqual("https", imposter.Protocol);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsName()
+        {
+            const string expectedName = "Service";
+            var imposter = new HttpsImposter(123, expectedName);
+            Assert.AreEqual(expectedName, imposter.Name);
+        }
+
+        [TestMethod]
+        public void Constructor_InitializesStubsCollection()
+        {
+            var imposter = new HttpsImposter(123, null);
+            Assert.IsNotNull(imposter.Stubs);
+        }
+
+        #endregion
+
+        #region Stub Tests
+
+        [TestMethod]
+        public void AddStub_AddsStubToCollection()
+        {
+            var imposter = new HttpsImposter(123, null);
+            imposter.AddStub();
+            Assert.AreEqual(1, imposter.Stubs.Count);
+        }
+                
+        #endregion
+    }
+}

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -43,6 +43,14 @@ namespace MbDotNet.Tests.Imposters
             Assert.IsNotNull(imposter.Stubs);
         }
 
+        [TestMethod]
+        public void Constructor_SetsKey()
+        {
+            var testKeyValue = "testKey";
+            var imposter = new HttpsImposter(123, null, testKeyValue);
+            Assert.AreEqual(imposter.Key, testKeyValue);
+        }
+
         #endregion
 
         #region Stub Tests

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -66,6 +66,13 @@ namespace MbDotNet.Tests.Imposters
             Assert.AreEqual(expectedCertValue, imposter.Cert);
         }
 
+        [TestMethod]
+        public void Constructor_SetsCertAsNullWhenMissing()
+        {
+            var imposter = new HttpsImposter(123, null);
+            Assert.IsNull(imposter.Cert);
+        }
+
         #endregion
 
         #region Stub Tests

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -46,9 +46,9 @@ namespace MbDotNet.Tests.Imposters
         [TestMethod]
         public void Constructor_SetsKey()
         {
-            var testKeyValue = "testKey";
-            var imposter = new HttpsImposter(123, null, testKeyValue, null);
-            Assert.AreEqual(imposter.Key, testKeyValue);
+            var expectedKeyValue = "testKey";
+            var imposter = new HttpsImposter(123, null, expectedKeyValue, null);
+            Assert.AreEqual(expectedKeyValue, imposter.Key);
         }
 
         [TestMethod]
@@ -61,9 +61,9 @@ namespace MbDotNet.Tests.Imposters
         [TestMethod]
         public void Constructor_SetsCert()
         {
-            var testCertValue = "testCert";
-            var imposter = new HttpsImposter(123, null, null, testCertValue);
-            Assert.AreEqual(imposter.Cert, testCertValue);
+            var expectedCertValue = "testCert";
+            var imposter = new HttpsImposter(123, null, null, expectedCertValue);
+            Assert.AreEqual(expectedCertValue, imposter.Cert);
         }
 
         #endregion

--- a/MbDotNet.Tests/MountebankClientTests.cs
+++ b/MbDotNet.Tests/MountebankClientTests.cs
@@ -170,7 +170,7 @@ namespace MbDotNet.Tests
 
             Assert.AreEqual(0, _client.Imposters.Count);
         }
-
+         
         [TestMethod]
         public void SubmitCollection_ShouldSubmitImpostersUsingProxy()
         {

--- a/MbDotNet/Interfaces/IClient.cs
+++ b/MbDotNet/Interfaces/IClient.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
+
 using MbDotNet.Enums;
-using MbDotNet.Models;
 using MbDotNet.Models.Imposters;
 
 namespace MbDotNet.Interfaces

--- a/MbDotNet/Interfaces/IClient.cs
+++ b/MbDotNet/Interfaces/IClient.cs
@@ -23,6 +23,17 @@ namespace MbDotNet.Interfaces
         /// <returns>The newly created imposter</returns>
         HttpImposter CreateHttpImposter(int port, string name = null);
 
+        /// <summary> 
+        /// Creates a new imposter on the specified port with the HTTPS protocol. The Submit method
+        /// must be called on the client in order to submit the imposter to mountebank.
+        /// </summary>
+        /// <param name="port">The port the imposter will be set up to receive requests on</param>
+        /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="key">The private key the imposter will use</param>
+        /// <param name="cert">The public certificate the imposer will use</param>
+        /// <returns>The newly created imposter</returns>
+        HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null);
+
         /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method
         /// must be called on the client in order to submit the imposter to mountebank.

--- a/MbDotNet/MbDotNet.csproj
+++ b/MbDotNet/MbDotNet.csproj
@@ -60,6 +60,7 @@
     <Compile Include="HttpClientWrapper.cs" />
     <Compile Include="Interfaces\IHttpClientWrapper.cs" />
     <Compile Include="Interfaces\IRequestProxy.cs" />
+    <Compile Include="Models\Imposters\HttpsImposter.cs" />
     <Compile Include="Models\Imposters\Request.cs" />
     <Compile Include="Models\Imposters\RetrievedImposter.cs" />
     <Compile Include="Models\Imposters\TcpImposter.cs" />

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -9,6 +9,7 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
         
+        // TODO Need to not include key in serialization when its null to allow mb to use self-signed certificate.
         [JsonProperty("key")]
         public string Key { get; private set; }
 

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -9,8 +9,8 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
         
-        // TODO Need to not include key in serialization when its null to allow mb to use self-signed certificate.
-        [JsonProperty("key")]
+        // TODO This won't serialize key, but how does a user of this imposter know it's using the self-signed cert?
+        [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
         public string Key { get; private set; }
 
         public HttpsImposter(int port, string name) : this(port, name, null)

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -10,14 +10,18 @@ namespace MbDotNet.Models.Imposters
         public ICollection<HttpStub> Stubs { get; private set; }
         
         // TODO This won't serialize key, but how does a user of this imposter know it's using the self-signed cert?
+        [JsonProperty("cert", NullValueHandling = NullValueHandling.Ignore)]
+        public string Cert { get; private set; }
+
+        // TODO This won't serialize key, but how does a user of this imposter know it's using the self-signed cert?
         [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
         public string Key { get; private set; }
 
-        public HttpsImposter(int port, string name) : this(port, name, null)
+        public HttpsImposter(int port, string name) : this(port, name, null, null)
         {
         }
 
-        public HttpsImposter(int port, string name, string key) : base(port, MbDotNet.Enums.Protocol.Https, name)
+        public HttpsImposter(int port, string name, string key, string cert) : base(port, MbDotNet.Enums.Protocol.Https, name)
         {
             Key = key;
             Stubs = new List<HttpStub>();

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using MbDotNet.Enums;
+using MbDotNet.Interfaces;
+using MbDotNet.Models.Stubs;
+using Newtonsoft.Json;
+
+namespace MbDotNet.Models.Imposters
+{
+    public class HttpsImposter : Imposter 
+    {
+        [JsonProperty("stubs")]
+        public ICollection<HttpStub> Stubs { get; private set; }
+
+        public HttpsImposter(int port, string name) : base(port, MbDotNet.Enums.Protocol.Https, name)
+        {
+            Stubs = new List<HttpStub>();
+        }
+
+        public HttpStub AddStub()
+        {
+            var stub = new HttpStub();
+            Stubs.Add(stub);
+            return stub;
+        }
+    }
+}

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -23,6 +23,7 @@ namespace MbDotNet.Models.Imposters
 
         public HttpsImposter(int port, string name, string key, string cert) : base(port, MbDotNet.Enums.Protocol.Https, name)
         {
+            Cert = cert;
             Key = key;
             Stubs = new List<HttpStub>();
         }

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -8,9 +8,17 @@ namespace MbDotNet.Models.Imposters
     {
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
+        
+        [JsonProperty("key")]
+        public string Key { get; private set; }
 
-        public HttpsImposter(int port, string name) : base(port, MbDotNet.Enums.Protocol.Https, name)
+        public HttpsImposter(int port, string name) : this(port, name, null)
         {
+        }
+
+        public HttpsImposter(int port, string name, string key) : base(port, MbDotNet.Enums.Protocol.Https, name)
+        {
+            Key = key;
             Stubs = new List<HttpStub>();
         }
 

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using MbDotNet.Enums;
-using MbDotNet.Interfaces;
-using MbDotNet.Models.Stubs;
+﻿using MbDotNet.Models.Stubs;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace MbDotNet.Models.Imposters
 {

--- a/MbDotNet/Models/Imposters/RetrievedImposter.cs
+++ b/MbDotNet/Models/Imposters/RetrievedImposter.cs
@@ -4,7 +4,6 @@ namespace MbDotNet.Models.Imposters
 {
     public class RetrievedImposter
     {
-
         /// <summary>
         /// The port the imposter is set up to accept requests on.
         /// </summary>
@@ -28,6 +27,5 @@ namespace MbDotNet.Models.Imposters
 
         [JsonProperty("requests")]
         public Request[] Requests { get; private set; }
-
     }
 }

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -41,6 +41,20 @@ namespace MbDotNet
         }
 
         /// <summary>
+        /// Creates a new imposter on the specified port with the HTTPS protocol. The Submit method
+        /// must be called on the client in order to submit the imposter to mountebank.
+        /// </summary>
+        /// <param name="port">The port the imposter will be set up to receive requests on</param>
+        /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="key">The private key the imposter will use</param>
+        /// <param name="cert">The public certificate the imposer will use</param>
+        /// <returns>The newly created imposter</returns>
+        public HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null)
+        {
+            return new HttpsImposter(port, name, key, cert);
+        }
+
+        /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method
         /// must be called on the client in order to submit the imposter to mountebank.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For usage examples, see the [Usage Examples (v2)](https://github.com/mattherman/
 ## Unsupported Functionality ##
 
 The following Mountebank functionality is not yet supported:
-- HTTPS and SMTP imposters
+- SMTP imposters
 - Stub behaviors
 - All response types other than "is"
 - The "exists", "or", "and", and "inject" predicates


### PR DESCRIPTION
# Add https imposter support
Summary of HttpsImposter functionality:
- the protocol is set to https
- the key and cert can be set on creation
- the mutualAuth key can't be set
- the GetImposters doesn't return any of the extra values an HttpsImposter has (key, cert and mutualAuth)

## Testing
 - [x] Unit tests for the HttpsImposter
 - [x] Unit tests for CreateHttpsImposter
 - [x] Acceptance test for creating an HttpsImposter

## Questions
 - Should the mutualAuth key be done in this pull request? This will impact the GetImposter code as it will need to get different types.
 - Should the GetImposter return the key and cert? Same impact as above.

## TBD
 - [x] Code Review
 - ~~Version bump (probably minor?)~~