### PR TITLE
Include mutualAuth property in HttpsImposter creation

### DIFF
--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -47,7 +47,7 @@ namespace MbDotNet.Tests.Imposters
         public void Constructor_SetsKey()
         {
             var expectedKeyValue = "testKey";
-            var imposter = new HttpsImposter(123, null, expectedKeyValue, null);
+            var imposter = new HttpsImposter(123, null, expectedKeyValue, null, false);
             Assert.AreEqual(expectedKeyValue, imposter.Key);
         }
 
@@ -62,7 +62,7 @@ namespace MbDotNet.Tests.Imposters
         public void Constructor_SetsCert()
         {
             var expectedCertValue = "testCert";
-            var imposter = new HttpsImposter(123, null, null, expectedCertValue);
+            var imposter = new HttpsImposter(123, null, null, expectedCertValue, false);
             Assert.AreEqual(expectedCertValue, imposter.Cert);
         }
 
@@ -71,6 +71,20 @@ namespace MbDotNet.Tests.Imposters
         {
             var imposter = new HttpsImposter(123, null);
             Assert.IsNull(imposter.Cert);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsMutualAuth()
+        {
+            var imposter = new HttpsImposter(123, null, null, null, true);
+            Assert.IsTrue(imposter.MutualAuthRequired);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsMutualAuthFalseWhenMissing()
+        {
+            var imposter = new HttpsImposter(123, null);
+            Assert.IsFalse(imposter.MutualAuthRequired);
         }
 
         #endregion

--- a/MbDotNet/Interfaces/IClient.cs
+++ b/MbDotNet/Interfaces/IClient.cs
@@ -31,8 +31,9 @@ namespace MbDotNet.Interfaces
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="key">The private key the imposter will use</param>
         /// <param name="cert">The public certificate the imposer will use</param>
+        /// <param name="mutualAuthRequired">Whether or not the server requires mutual auth</param>
         /// <returns>The newly created imposter</returns>
-        HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null);
+        HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false);
 
         /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -9,22 +9,24 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
         
-        // TODO This won't serialize key, but how does a user of this imposter know it's using the self-signed cert?
         [JsonProperty("cert", NullValueHandling = NullValueHandling.Ignore)]
         public string Cert { get; private set; }
 
-        // TODO This won't serialize key, but how does a user of this imposter know it's using the self-signed cert?
         [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
         public string Key { get; private set; }
 
-        public HttpsImposter(int port, string name) : this(port, name, null, null)
+        [JsonProperty("mutualAuth")]
+        public bool MutualAuthRequired { get; private set; }
+
+        public HttpsImposter(int port, string name) : this(port, name, null, null, false)
         {
         }
 
-        public HttpsImposter(int port, string name, string key, string cert) : base(port, MbDotNet.Enums.Protocol.Https, name)
+        public HttpsImposter(int port, string name, string key, string cert, bool mutualAuthRequired) : base(port, Enums.Protocol.Https, name)
         {
             Cert = cert;
             Key = key;
+            MutualAuthRequired = mutualAuthRequired;
             Stubs = new List<HttpStub>();
         }
 

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -48,10 +48,11 @@ namespace MbDotNet
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="key">The private key the imposter will use</param>
         /// <param name="cert">The public certificate the imposer will use</param>
+        /// <param name="mutualAuthRequired">Whether or not the server will require mutual auth</param>
         /// <returns>The newly created imposter</returns>
-        public HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null)
+        public HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false)
         {
-            return new HttpsImposter(port, name, key, cert);
+            return new HttpsImposter(port, name, key, cert, mutualAuthRequired);
         }
 
         /// <summary>


### PR DESCRIPTION
Adding the HTTPS imposter property `mutualAuth` to the creation of these imposters. Leftover from #22.