### PR TITLE
Added support for dynamic imposter ports

### DIFF
--- a/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTest.cs
@@ -10,5 +10,6 @@ namespace MbDotNet.Acceptance.Tests
         public static void CanDeleteImposter(MountebankClient client) => new CanDeleteImposter(client).Run();
         public static void CanNotGetImposterThatDoesNotExist(MountebankClient client) => new CanNotGetImposterThatDoesNotExist(client).Run();
         public static void CanVerifyCallsOnImposter(MountebankClient client) => new CanVerifyCallsOnImposter(client).Run();
+        public static void CanCreateAndGetHttpImposterWithNoPort(MountebankClient client) => new CanCreateAndGetHttpImposterWithNoPort(client).Run();
     }
 }

--- a/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateAndGetHttpImposterWithNoPort.cs
+++ b/MbDotNet.Acceptance.Tests/AcceptanceTests/CanCreateAndGetHttpImposterWithNoPort.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using MbDotNet.Models.Imposters;
+
+namespace MbDotNet.Acceptance.Tests.AcceptanceTests
+{
+    internal class CanCreateAndGetHttpImposterWithNoPort
+    {
+        private readonly MountebankClient _client;
+        private Imposter _imposter = null;
+        private RetrievedHttpImposter _retrievedImposter;
+
+        public CanCreateAndGetHttpImposterWithNoPort(MountebankClient client)
+        {
+            _client = client;
+        }
+
+        public void Run()
+        {
+            DeleteAllImposters();
+            CreateImposter();
+            GetImposter();
+            VerifyImposterWasRetrieved();
+            DeleteAllImposters();
+        }
+
+        private void GetImposter()
+        {
+            _retrievedImposter = _client.GetHttpImposter(_imposter.Port.Value);
+        }
+
+        private void DeleteAllImposters()
+        {
+            _client.DeleteAllImposters();
+        }
+
+        private void VerifyImposterWasRetrieved()
+        {
+            _retrievedImposter.Should().NotBeNull("Expected imposter to have been retrieved");
+            _retrievedImposter.Port.Should().Equals(_imposter.Port);
+        }
+
+        private void CreateImposter()
+        {
+            _imposter = _client.CreateHttpImposter();
+            _client.Submit(_imposter);
+        }
+    }
+}

--- a/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
+++ b/MbDotNet.Acceptance.Tests/MbDotNet.Acceptance.Tests.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AcceptanceTest.cs" />
+    <Compile Include="AcceptanceTests\CanCreateAndGetHttpImposterWithNoPort.cs" />
     <Compile Include="AcceptanceTests\CanCreateAndGetTcpImposter.cs" />
     <Compile Include="AcceptanceTests\CanDeleteImposter.cs" />
     <Compile Include="AcceptanceTests\CanCreateAndGetHttpImposter.cs" />

--- a/MbDotNet.Acceptance.Tests/Program.cs
+++ b/MbDotNet.Acceptance.Tests/Program.cs
@@ -25,6 +25,7 @@ namespace MbDotNet.Acceptance.Tests
                 AcceptanceTest.CanCreateAndGetTcpImposter(Client);
                 AcceptanceTest.CanDeleteImposter(Client);
                 AcceptanceTest.CanVerifyCallsOnImposter(Client);
+                AcceptanceTest.CanCreateAndGetHttpImposterWithNoPort(Client);
             }
             catch (Exception ex)
             {

--- a/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
@@ -31,5 +31,15 @@ namespace MbDotNet.Tests.Client
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedName, imposter.Name);
         }
+
+        [TestMethod]
+        public void WithoutPortAndName_SetsPortAndNameToNull()
+        {
+            var imposter = Client.CreateHttpImposter();
+
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Port);
+            Assert.IsNull(imposter.Name);
+        }
     }
 }

--- a/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
@@ -53,5 +53,15 @@ namespace MbDotNet.Tests.Client
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedCert, imposter.Cert);
         }
+
+        [TestMethod]
+        public void WithoutPortAndName_SetsPortAndNameToNull()
+        {
+            var imposter = Client.CreateHttpsImposter();
+
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Port);
+            Assert.IsNull(imposter.Name);
+        }
     }
 }

--- a/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
@@ -55,5 +55,15 @@ namespace MbDotNet.Tests.Client
             Client.CreateTcpImposter(123);
             Assert.AreEqual(0, this.Client.Imposters.Count);
         }
+
+        [TestMethod]
+        public void WithoutPortAndName_SetsPortAndNameToNull()
+        {
+            var imposter = Client.CreateTcpImposter();
+
+            Assert.IsNotNull(imposter);
+            Assert.IsNull(imposter.Port);
+            Assert.IsNull(imposter.Name);
+        }
     }
 }

--- a/MbDotNet.Tests/Client/SubmitTests.cs
+++ b/MbDotNet.Tests/Client/SubmitTests.cs
@@ -49,8 +49,18 @@ namespace MbDotNet.Tests.Client
 
             Client.Submit(new[] { imposter1, imposter2 });
 
-            Assert.AreEqual(1, Client.Imposters.Count(x => x.Port == firstPortNumber));
-            Assert.AreEqual(1, Client.Imposters.Count(x => x.Port == secondPortNumber));
+            Assert.AreEqual(1, Client.Imposters.Count(x => x.Port.Value == firstPortNumber));
+            Assert.AreEqual(1, Client.Imposters.Count(x => x.Port.Value == secondPortNumber));
+        }
+
+        [TestMethod]
+        public void Submit_AllowsNullPort()
+        {
+            var imposter = new HttpImposter(null, null);
+
+            Client.Submit(imposter);
+
+            MockRequestProxy.Verify(x => x.CreateImposter(It.Is<Imposter>(imp => imp.Port == null)), Times.Once);
         }
     }
 }

--- a/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpImposterTests.cs
@@ -35,6 +35,13 @@ namespace MbDotNet.Tests.Models.Imposters
         }
 
         [TestMethod]
+        public void Constructor_AllowsNullPort()
+        {
+            var imposter = new HttpImposter(null, null);
+            Assert.IsNull(imposter.Port);
+        }
+
+        [TestMethod]
         public void Constructor_InitializesStubsCollection()
         {
             var imposter = new HttpImposter(123, null);

--- a/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/HttpsImposterTests.cs
@@ -35,6 +35,13 @@ namespace MbDotNet.Tests.Models.Imposters
         }
 
         [TestMethod]
+        public void Constructor_AllowsNullPort()
+        {
+            var imposter = new HttpsImposter(null, null);
+            Assert.IsNull(imposter.Port);
+        }
+
+        [TestMethod]
         public void Constructor_InitializesStubsCollection()
         {
             var imposter = new HttpsImposter(123, null);

--- a/MbDotNet.Tests/Models/Imposters/TcpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/TcpImposterTests.cs
@@ -41,6 +41,13 @@ namespace MbDotNet.Tests.Models.Imposters
         }
 
         [TestMethod]
+        public void Constructor_AllowsNullPort()
+        {
+            var imposter = new TcpImposter(null, null, TcpMode.Text);
+            Assert.IsNull(imposter.Port);
+        }
+
+        [TestMethod]
         public void Constructor_InitializesStubsCollection()
         {
             var imposter = new TcpImposter(123, null, TcpMode.Text);

--- a/MbDotNet.Tests/MountebankRequestProxyTests.cs
+++ b/MbDotNet.Tests/MountebankRequestProxyTests.cs
@@ -112,6 +112,36 @@ namespace MbDotNet.Tests
         }
 
         [TestMethod]
+        public void CreateImposter_SendsRequest_ImposterWithNoPort()
+        {
+            var response = new HttpResponseMessage();
+            response.StatusCode = HttpStatusCode.Created;
+            response.Content = new StringContent(@"
+            {
+                ""protocol"": ""http"",
+                ""port"": 12345,
+                ""numberOfRequests"": 0,
+                ""requests"": [],
+                ""stubs"": [],
+                ""_links"": {
+                    ""self"": {
+                        ""href"": ""http://localhost:2525/imposters/64735""
+                    }
+                }
+            }
+            ");
+
+            _mockClient.Setup(x => x.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>()))
+                .ReturnsAsync(response);
+
+            var imposter = new HttpImposter(null, null);
+
+            _proxy.CreateImposter(imposter);
+
+            Assert.AreEqual(12345, imposter.Port);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(MountebankException))]
         public void CreateImposter_StatusCodeNotCreated_ThrowsMountebankException()
         {
@@ -123,7 +153,7 @@ namespace MbDotNet.Tests
             _proxy.CreateImposter(new HttpImposter(123, null));
         }
 
-        private HttpResponseMessage GetResponse(HttpStatusCode statusCode) 
+        private HttpResponseMessage GetResponse(HttpStatusCode statusCode)
         {
             var response = new HttpResponseMessage();
             response.StatusCode = statusCode;

--- a/MbDotNet.Tests/TutorialExamples.cs
+++ b/MbDotNet.Tests/TutorialExamples.cs
@@ -55,6 +55,20 @@ namespace MbDotNet.Tests
         }
 
         /// <summary>
+        /// This test shows how to setup the imposter with a dynamic port chosen by Mountebank
+        /// See imposter resource at http://www.mbtest.org/docs/api/contracts for more information.
+        /// </summary>
+        //[TestMethod]
+        public void DynamicPortExample()
+        {
+            var imposter = _client.CreateHttpImposter(null, "DynamicPort");
+
+            _client.Submit(imposter);
+
+            var portAssignedByMountebank = imposter.Port;
+        }
+
+        /// <summary>
         /// This test shows how to setup the imposter in the equals predicate example
         /// at http://www.mbtest.org/docs/api/predicates.
         /// </summary>

--- a/MbDotNet/IClient.cs
+++ b/MbDotNet/IClient.cs
@@ -21,7 +21,7 @@ namespace MbDotNet
         /// <param name="port">The port the imposter will be set up to receive requests on</param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <returns>The newly created imposter</returns>
-        HttpImposter CreateHttpImposter(int port, string name = null);
+        HttpImposter CreateHttpImposter(int? port = null, string name = null);
 
         /// <summary> 
         /// Creates a new imposter on the specified port with the HTTPS protocol. The Submit method
@@ -33,7 +33,7 @@ namespace MbDotNet
         /// <param name="cert">The public certificate the imposer will use</param>
         /// <param name="mutualAuthRequired">Whether or not the server requires mutual auth</param>
         /// <returns>The newly created imposter</returns>
-        HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false);
+        HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false);
 
         /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method
@@ -43,7 +43,7 @@ namespace MbDotNet
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="mode">The mode of the imposter, text or binary. This defines the encoding for request/response data</param>
         /// <returns>The newly created imposter</returns>
-        TcpImposter CreateTcpImposter(int port, string name = null, TcpMode mode = TcpMode.Text);
+        TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text);
 
         /// <summary>
         /// Retrieves an HttpImposter along with information about requests made to that

--- a/MbDotNet/IClient.cs
+++ b/MbDotNet/IClient.cs
@@ -16,18 +16,26 @@ namespace MbDotNet
 
         /// <summary>
         /// Creates a new imposter on the specified port with the HTTP protocol. The Submit method
-        /// must be called on the client in order to submit the imposter to mountebank.
+        /// must be called on the client in order to submit the imposter to mountebank. If the port
+        /// is blank, Mountebank will assign one which can be retrieved after Submit.
         /// </summary>
-        /// <param name="port">The port the imposter will be set up to receive requests on</param>
+        /// <param name="port">
+        /// The port the imposter will be set up to receive requests on, or null to allow
+        /// Mountebank to set the port.
+        /// </param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <returns>The newly created imposter</returns>
         HttpImposter CreateHttpImposter(int? port = null, string name = null);
 
         /// <summary> 
         /// Creates a new imposter on the specified port with the HTTPS protocol. The Submit method
-        /// must be called on the client in order to submit the imposter to mountebank.
+        /// must be called on the client in order to submit the imposter to mountebank. If the port
+        /// is blank, Mountebank will assign one which can be retrieved after Submit.
         /// </summary>
-        /// <param name="port">The port the imposter will be set up to receive requests on</param>
+        /// <param name="port">
+        /// The port the imposter will be set up to receive requests on, or null to allow
+        /// Mountebank to set the port.
+        /// </param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="key">The private key the imposter will use</param>
         /// <param name="cert">The public certificate the imposer will use</param>
@@ -37,9 +45,13 @@ namespace MbDotNet
 
         /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method
-        /// must be called on the client in order to submit the imposter to mountebank.
+        /// must be called on the client in order to submit the imposter to mountebank. If the port
+        /// is blank, Mountebank will assign one which can be retrieved after Submit.
         /// </summary>
-        /// <param name="port">The port the imposter will be set up to receive requests on</param>
+        /// <param name="port">
+        /// The port the imposter will be set up to receive requests on, or null to allow
+        /// Mountebank to set the port.
+        /// </param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="mode">The mode of the imposter, text or binary. This defines the encoding for request/response data</param>
         /// <returns>The newly created imposter</returns>

--- a/MbDotNet/MbDotNet.csproj
+++ b/MbDotNet/MbDotNet.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Models\Predicates\NotPredicate.cs" />
     <Compile Include="Models\Predicates\StartsWithPredicate.cs" />
     <Compile Include="Models\Requests\TcpRequest.cs" />
+    <Compile Include="Models\Responses\CreateImposterResponse.cs" />
     <Compile Include="Models\Stubs\HttpStub.cs" />
     <Compile Include="Models\Imposters\HttpImposter.cs" />
     <Compile Include="IClient.cs" />

--- a/MbDotNet/Models/Imposters/HttpImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpImposter.cs
@@ -9,7 +9,7 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
 
-        public HttpImposter(int port, string name) : base(port, Enums.Protocol.Http, name)
+        public HttpImposter(int? port, string name) : base(port, Enums.Protocol.Http, name)
         {
             Stubs = new List<HttpStub>();
         }

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -18,11 +18,11 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("mutualAuth")]
         public bool MutualAuthRequired { get; private set; }
 
-        public HttpsImposter(int port, string name) : this(port, name, null, null, false)
+        public HttpsImposter(int? port, string name) : this(port, name, null, null, false)
         {
         }
 
-        public HttpsImposter(int port, string name, string key, string cert, bool mutualAuthRequired) : base(port, Enums.Protocol.Https, name)
+        public HttpsImposter(int? port, string name, string key, string cert, bool mutualAuthRequired) : base(port, Enums.Protocol.Https, name)
         {
             Cert = cert;
             Key = key;

--- a/MbDotNet/Models/Imposters/Imposter.cs
+++ b/MbDotNet/Models/Imposters/Imposter.cs
@@ -1,4 +1,5 @@
 ﻿using MbDotNet.Enums;
+using MbDotNet.Exceptions;
 using Newtonsoft.Json;
 
 namespace MbDotNet.Models.Imposters
@@ -8,8 +9,8 @@ namespace MbDotNet.Models.Imposters
         /// <summary>
         /// The port the imposter is set up to accept requests on.
         /// </summary>
-        [JsonProperty("port")]
-        public int Port { get; private set; }
+        [JsonProperty(PropertyName = "port", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Port { get; private set; }
 
         /// <summary>
         /// The protocol the imposter is set up to accept requests through.
@@ -23,8 +24,18 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("name")]
         public string Name { get; private set; }
 
+        internal void SetDynamicPort(int port)
+        {
+            if (Port != null)
+            {
+                throw new MountebankException("Cannot change imposter port once it has been set.");
+            }
+
+            Port = port;
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Set as virtual for testing purposes")]
-        public Imposter(int port, Protocol protocol, string name)
+        public Imposter(int? port, Protocol protocol, string name)
         {
             Port = port;
             Protocol = protocol.ToString().ToLower();

--- a/MbDotNet/Models/Imposters/TcpImposter.cs
+++ b/MbDotNet/Models/Imposters/TcpImposter.cs
@@ -13,7 +13,7 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("mode")]
         public string Mode { get; private set; }
 
-        public TcpImposter(int port, string name, TcpMode mode) : base(port, Enums.Protocol.Tcp, name)
+        public TcpImposter(int? port, string name, TcpMode mode) : base(port, Enums.Protocol.Tcp, name)
         {
             Stubs = new List<TcpStub>();
             Mode = mode.ToString().ToLower();

--- a/MbDotNet/Models/Responses/CreateImposterResponse.cs
+++ b/MbDotNet/Models/Responses/CreateImposterResponse.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MbDotNet.Models.Responses
+{
+    internal class CreateImposterResponse
+    {
+        /// <summary>
+        /// The port the imposter is set up to accept requests on.
+        /// </summary>
+        [JsonProperty("port")]
+        public int Port { get; internal set; }
+
+    }
+}

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -36,7 +36,7 @@ namespace MbDotNet
         /// <param name="port">The port the imposter will be set up to receive requests on</param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <returns>The newly created imposter</returns>
-        public HttpImposter CreateHttpImposter(int port, string name = null)
+        public HttpImposter CreateHttpImposter(int? port = null, string name = null)
         {
             return new HttpImposter(port, name);
         }
@@ -53,7 +53,7 @@ namespace MbDotNet
         /// <param name="cert">The public certificate the imposer will use, MUST be a PEM-formatted string</param>
         /// <param name="mutualAuthRequired">Whether or not the server will require mutual auth</param>
         /// <returns>The newly created imposter</returns>
-        public HttpsImposter CreateHttpsImposter(int port, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false)
+        public HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false)
         {
             return new HttpsImposter(port, name, key, cert, mutualAuthRequired);
         }
@@ -66,7 +66,7 @@ namespace MbDotNet
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="mode">The mode of the imposter, text or binary. This defines the encoding for request/response data</param>
         /// <returns>The newly created imposter</returns>
-        public TcpImposter CreateTcpImposter(int port, string name = null, TcpMode mode = TcpMode.Text)
+        public TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text)
         {
             return new TcpImposter(port, name, mode);
         }

--- a/MbDotNet/MountebankRequestProxy.cs
+++ b/MbDotNet/MountebankRequestProxy.cs
@@ -5,6 +5,7 @@ using MbDotNet.Exceptions;
 using MbDotNet.Models.Imposters;
 using Newtonsoft.Json;
 using System.Text.RegularExpressions;
+using MbDotNet.Models.Responses;
 
 namespace MbDotNet
 {
@@ -130,8 +131,8 @@ namespace MbDotNet
                 try
                 {
                     var content = response.Content.ReadAsStringAsync().Result;
-                    Match match = new Regex(".*\"port\": (\\d+),", RegexOptions.Multiline).Match(content);
-                    imposter.SetDynamicPort(Convert.ToInt32(match.Groups[1].Value));
+                    var returnedImposter = JsonConvert.DeserializeObject<CreateImposterResponse>(content);
+                    imposter.SetDynamicPort(returnedImposter.Port);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Made a number of changes to support dynamic clients:

1. Made port a nullable int? parameter on imposter constructors that defaults to null
2. Made port a nullable int? parameter on the factory methods exposed on the MB client
3. Updated the MountebankRequestProxy to set the Imposter port after submit for create requests
4. Added unit test cases for imposter constructors and mountebank client factory methods
5. Added a unit test for the request proxy to ensure that port is stripped from response content
6. Added an acceptance test verifying that the port can be null and is properly set  on the imposter after create.
7. Added example to the tutorial class for creating an imposter with no port.

Thanks again for building this client!