### PR TITLE
Rely on default port value instead of forcing it to be nullable

### DIFF
--- a/MbDotNet/Models/Imposters/Imposter.cs
+++ b/MbDotNet/Models/Imposters/Imposter.cs
@@ -10,7 +10,7 @@ namespace MbDotNet.Models.Imposters
         /// The port the imposter is set up to accept requests on.
         /// </summary>
         [JsonProperty(PropertyName = "port", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Port { get; private set; }
+        public int Port { get; private set; }
 
         /// <summary>
         /// The protocol the imposter is set up to accept requests through.
@@ -26,7 +26,7 @@ namespace MbDotNet.Models.Imposters
 
         internal void SetDynamicPort(int port)
         {
-            if (Port != null)
+            if (Port != default(Port))
             {
                 throw new MountebankException("Cannot change imposter port once it has been set.");
             }
@@ -37,7 +37,10 @@ namespace MbDotNet.Models.Imposters
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Set as virtual for testing purposes")]
         public Imposter(int? port, Protocol protocol, string name)
         {
-            Port = port;
+            if (port.HasValue) {
+                Port = port.Value;
+            }
+            
             Protocol = protocol.ToString().ToLower();
             Name = name;
         }

--- a/MbDotNet/MountebankRequestProxy.cs
+++ b/MbDotNet/MountebankRequestProxy.cs
@@ -126,7 +126,7 @@ namespace MbDotNet
 
         private void HandleDynamicPort(HttpResponseMessage response, Imposter imposter)
         {
-            if (imposter.Port == null)
+            if (imposter.Port == default(imposter.Port))
             {
                 try
                 {


### PR DESCRIPTION
I was thinking about the recent change to allow an imposter's port to be set dynamically and I wasn't satisfied with the breaking change we made.

I am considering going back to a non-nullable port property and forcing checks to rely on the port's value to determine if it should be set dynamically. We had rejected this previously because it would cause us to sprinkle some magic numbers all over the place. However, I was able to isolate it to the Imposter and MountebankRequestProxy classes. I also used `default` to get the comparison value instead of hardcoding zero.

~@SuperDrew I would appreciate your opinion on this since you worked on the original change.~

Also, ignore the failing build for now, I didn't have the ability to actually build the project when I made these changes, just wanted to make them for reference. I'll update everything else if we decide to go this route.