### PR TITLE
Allow building on non-Windows machines

### DIFF
--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MbDotNetKey.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <Copyright>Copyright ©  2017</Copyright>
     <Version>3.1.0</Version>
     <FileVersion>3.0.0.0</FileVersion>
@@ -16,7 +17,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="Refit" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MbDotNet/MbDotNet.csproj
+++ b/MbDotNet/MbDotNet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MbDotNetKey.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <FileVersion>4.0.0.0</FileVersion>
 


### PR DESCRIPTION
Full assembly signing is [not supported yet](https://github.com/dotnet/cli/issues/6911). As described in that issue, using the PublicSign option on non-Windows machines will allow the project to build. When the project is packaged it will still need to be built on a Windows machine in order to fully sign the assemblies.

I also removed the Refit dependency because it was causing build issues for me on openSUSE and the project did not actually depend on it.