### PR TITLE
Remove unused .NET Framework files

### DIFF
--- a/MbDotNet.Acceptance.Tests/App.config
+++ b/MbDotNet.Acceptance.Tests/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/MbDotNet.Tests/packages.config
+++ b/MbDotNet.Tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-</packages>

--- a/MbDotNet/Properties/AssemblyInfo.cs
+++ b/MbDotNet/Properties/AssemblyInfo.cs
@@ -1,29 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("8a9a51ae-32ad-412d-a8f3-683af705ce80")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MbDotNet.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a1f31a5ad77555d5a2e97612cb7741558af7024e527a6ee1f4200b6423f638bbfd1c316a74b7ec91bfc987c74b3467165ad5ce09110319cfa6243a1688877c61d47054fa6d460c7c6a5cbffa0998471445f65888ddfa47946765ed21e5e268bafe3d2fbe145668d6d918fad8b5719c319b18982a9e5a310d9967c7f03ca4dbd3")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]


### PR DESCRIPTION
Random unused files leftover from the transition to netstandard. Still need to keep the AssemblyInfo file around for InternalsVisibleTo since [it is not supported in the csproj file yet](https://stackoverflow.com/questions/39163558/do-i-need-assemblyinfo-while-working-with-net-core).