### PR TITLE
Enable/disable mock mode from client

### DIFF
--- a/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpImposterTests.cs
@@ -35,7 +35,7 @@ namespace MbDotNet.Tests.Client
             
             Assert.IsNotNull(imposter);
             Assert.AreEqual(expectedName, imposter.Name);
-        }
+        }        
 
         [TestMethod]
         public void HttpImposter_WithoutPortAndName_SetsPortAndNameToNull()
@@ -47,6 +47,22 @@ namespace MbDotNet.Tests.Client
             Assert.IsNull(imposter.Name);
         }
 
-       
+        [TestMethod]
+        public void HttpImposter_WithoutRecordRequests_SetsRecordRequest()
+        {
+            var imposter = Client.CreateHttpImposter(123, "service");
+
+            Assert.IsFalse(imposter.RecordRequests);
+        }
+
+        [TestMethod]
+        public void HttpImposter_WithRecordRequests_SetsRecordRequest()
+        {
+            const bool recordRequests = true;
+
+            var imposter = Client.CreateHttpImposter(123, "service", recordRequests);
+
+            Assert.IsTrue(imposter.RecordRequests);
+        }
     }
 }

--- a/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateHttpsImposterTests.cs
@@ -63,5 +63,23 @@ namespace MbDotNet.Tests.Client
             Assert.AreEqual(default(int), imposter.Port);
             Assert.IsNull(imposter.Name);
         }
+
+        [TestMethod]
+        public void HttpsImposter_WithoutRecordRequests_SetsRecordRequest()
+        {
+            var imposter = Client.CreateHttpsImposter();
+
+            Assert.IsFalse(imposter.RecordRequests);
+        }
+
+        [TestMethod]
+        public void HttpsImposter_WithRecordRequests_SetsRecordRequest()
+        {
+            const bool recordRequests = true;
+
+            var imposter = Client.CreateHttpsImposter(recordRequests: recordRequests);
+
+            Assert.IsTrue(imposter.RecordRequests);
+        }
     }
 }

--- a/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
+++ b/MbDotNet.Tests/Client/CreateTcpImposterTests.cs
@@ -65,5 +65,23 @@ namespace MbDotNet.Tests.Client
             Assert.AreEqual(default(int), imposter.Port);
             Assert.IsNull(imposter.Name);
         }
+
+        [TestMethod]
+        public void TcpImposter_WithoutRecordRequests_SetsRecordRequest()
+        {
+            var imposter = Client.CreateTcpImposter();
+
+            Assert.IsFalse(imposter.RecordRequests);
+        }
+
+        [TestMethod]
+        public void TcpImposter_WithRecordRequests_SetsRecordRequest()
+        {
+            const bool recordRequests = true;
+
+            var imposter = Client.CreateTcpImposter(recordRequests: recordRequests);
+
+            Assert.IsTrue(imposter.RecordRequests);
+        }
     }
 }

--- a/MbDotNet/IClient.cs
+++ b/MbDotNet/IClient.cs
@@ -24,8 +24,13 @@ namespace MbDotNet
         /// Mountebank to set the port.
         /// </param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        HttpImposter CreateHttpImposter(int? port = null, string name = null);
+        HttpImposter CreateHttpImposter(int? port = null, string name = null, bool recordRequests = false);
 
         /// <summary> 
         /// Creates a new imposter on the specified port with the HTTPS protocol. The Submit method
@@ -40,8 +45,13 @@ namespace MbDotNet
         /// <param name="key">The private key the imposter will use</param>
         /// <param name="cert">The public certificate the imposer will use</param>
         /// <param name="mutualAuthRequired">Whether or not the server requires mutual auth</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false);
+        HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false, bool recordRequests = false);
 
         /// <summary>
         /// Creates a new imposter on the specified port with the TCP protocol. The Submit method
@@ -54,8 +64,13 @@ namespace MbDotNet
         /// </param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="mode">The mode of the imposter, text or binary. This defines the encoding for request/response data</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text);
+        TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text, bool recordRequests = false);
 
         /// <summary>
         /// Retrieves an HttpImposter along with information about requests made to that

--- a/MbDotNet/Models/Imposters/HttpImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpImposter.cs
@@ -9,7 +9,7 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("stubs")]
         public ICollection<HttpStub> Stubs { get; private set; }
 
-        public HttpImposter(int? port, string name) : base(port, Enums.Protocol.Http, name)
+        public HttpImposter(int? port, string name, bool recordRequests = false) : base(port, Enums.Protocol.Http, name, recordRequests)
         {
             Stubs = new List<HttpStub>();
         }

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -18,11 +18,11 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("mutualAuth")]
         public bool MutualAuthRequired { get; private set; }
 
-        public HttpsImposter(int? port, string name) : this(port, name, null, null, false)
+        public HttpsImposter(int? port, string name, bool recordRequests = false) : this(port, name, null, null, false, recordRequests)
         {
         }
 
-        public HttpsImposter(int? port, string name, string key, string cert, bool mutualAuthRequired) : base(port, Enums.Protocol.Https, name)
+        public HttpsImposter(int? port, string name, string key, string cert, bool mutualAuthRequired, bool recordRequests = false) : base(port, Enums.Protocol.Https, name, recordRequests)
         {
             Cert = cert;
             Key = key;

--- a/MbDotNet/Models/Imposters/Imposter.cs
+++ b/MbDotNet/Models/Imposters/Imposter.cs
@@ -24,6 +24,12 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("name")]
         public string Name { get; private set; }
 
+        /// <summary>
+        /// Enables recording requests to use the imposter as a mock. See <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank verification.
+        /// </summary>
+        [JsonProperty("recordRequests")]
+        public bool RecordRequests { get; private set; }
+
         internal void SetDynamicPort(int port)
         {
             if (Port != default(int))
@@ -35,7 +41,7 @@ namespace MbDotNet.Models.Imposters
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Set as virtual for testing purposes")]
-        public Imposter(int? port, Protocol protocol, string name)
+        public Imposter(int? port, Protocol protocol, string name, bool recordRequests)
         {
             if (port.HasValue)
             {
@@ -44,6 +50,7 @@ namespace MbDotNet.Models.Imposters
             
             Protocol = protocol.ToString().ToLower();
             Name = name;
+            RecordRequests = recordRequests;
         }
     }
 }

--- a/MbDotNet/Models/Imposters/TcpImposter.cs
+++ b/MbDotNet/Models/Imposters/TcpImposter.cs
@@ -13,7 +13,7 @@ namespace MbDotNet.Models.Imposters
         [JsonProperty("mode")]
         public string Mode { get; private set; }
 
-        public TcpImposter(int? port, string name, TcpMode mode) : base(port, Enums.Protocol.Tcp, name)
+        public TcpImposter(int? port, string name, TcpMode mode, bool recordRequests = false) : base(port, Enums.Protocol.Tcp, name, recordRequests)
         {
             Stubs = new List<TcpStub>();
             Mode = mode.ToString().ToLower();

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -33,10 +33,15 @@ namespace MbDotNet
         /// </summary>
         /// <param name="port">The port the imposter will be set up to receive requests on</param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        public HttpImposter CreateHttpImposter(int? port = null, string name = null)
+        public HttpImposter CreateHttpImposter(int? port = null, string name = null, bool recordRequests = false)
         {
-            return new HttpImposter(port, name);
+            return new HttpImposter(port, name, recordRequests);
         }
 
         /// <summary>
@@ -50,10 +55,15 @@ namespace MbDotNet
         /// <param name="key">The private key the imposter will use, MUST be a PEM-formatted string</param>
         /// <param name="cert">The public certificate the imposer will use, MUST be a PEM-formatted string</param>
         /// <param name="mutualAuthRequired">Whether or not the server will require mutual auth</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        public HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false)
+        public HttpsImposter CreateHttpsImposter(int? port = null, string name = null, string key = null, string cert = null, bool mutualAuthRequired = false, bool recordRequests = false)
         {
-            return new HttpsImposter(port, name, key, cert, mutualAuthRequired);
+            return new HttpsImposter(port, name, key, cert, mutualAuthRequired, recordRequests);
         }
 
         /// <summary>
@@ -63,10 +73,15 @@ namespace MbDotNet
         /// <param name="port">The port the imposter will be set up to receive requests on</param>
         /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
         /// <param name="mode">The mode of the imposter, text or binary. This defines the encoding for request/response data</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
         /// <returns>The newly created imposter</returns>
-        public TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text)
+        public TcpImposter CreateTcpImposter(int? port = null, string name = null, TcpMode mode = TcpMode.Text, bool recordRequests = false)
         {
-            return new TcpImposter(port, name, mode);
+            return new TcpImposter(port, name, mode, recordRequests);
         }
 
         /// <summary>


### PR DESCRIPTION
Before this commit, it was required to start the Mountebank server
with the `--mock` option to be able to use mock verification. As
explained [here](http://www.mbtest.org/docs/api/mocks), it is
possible to enable the mock mode on an imposter by creating
the imposter with the `recordRequest` option set to `true`.

Making this option available from the Mountebank .net client
makes it easier for the test writer to enable mock verification
without having to change the startup options of the mountebank
server that may already be running.