### PR TITLE
#70 Added the "Exists" predicate functionality

### DIFF
--- a/MbDotNet.Tests/Acceptance/DocumentationTests.cs
+++ b/MbDotNet.Tests/Acceptance/DocumentationTests.cs
@@ -311,11 +311,47 @@ namespace MbDotNet.Tests.Acceptance
             await _client.SubmitAsync(imposter);
         }
 
-		/// <summary>
-		/// This test shows how to setup the imposter in the not predicate example
-		/// at http://www.mbtest.org/docs/api/predicates.
-		/// </summary>
-		[TestMethod]
+        /// <summary>
+        /// This test shows how to setup the imposter in the exists predicate example
+        /// at http://www.mbtest.org/docs/api/predicates.
+        /// </summary>
+        [TestMethod]
+        public async Task ExistsPredicateExample()
+        {
+            var imposter = _client.CreateHttpImposter(4550, "ExistsPredicateExample");
+
+            // First stub
+            var predicateFields = new HttpPredicateFields
+            {
+                RequestBody = new
+                {
+                    Message = true
+                }
+            };
+
+            imposter.AddStub().On(new ExistsPredicate<HttpPredicateFields>(predicateFields))
+                .ReturnsBody(HttpStatusCode.OK, "Success");
+
+            // Second stub
+            predicateFields = new HttpPredicateFields
+            {
+                RequestBody = new
+                {
+                    Message = false
+                }
+            };
+
+            imposter.AddStub().On(new ExistsPredicate<HttpPredicateFields>(predicateFields))
+                .ReturnsBody(HttpStatusCode.BadRequest, "You need to add a message parameter");
+
+            await _client.SubmitAsync(imposter);
+        }
+
+        /// <summary>
+        /// This test shows how to setup the imposter in the not predicate example
+        /// at http://www.mbtest.org/docs/api/predicates.
+        /// </summary>
+        [TestMethod]
 		public async Task NotPredicateExample()
         {
             var imposter = _client.CreateTcpImposter(4552, "NotPredicateExample");

--- a/MbDotNet.Tests/Models/Predicates/ExistsPredicateTests.cs
+++ b/MbDotNet.Tests/Models/Predicates/ExistsPredicateTests.cs
@@ -1,0 +1,55 @@
+﻿using MbDotNet.Models.Predicates;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MbDotNet.Tests.Models.Predicates
+{
+    [TestClass, TestCategory("Unit")]
+    public class ExistsPredicateTests : PredicateTestBase
+    {
+        [TestMethod]
+        public void MatchesPredicate_Constructor_SetsFieldObject()
+        {
+            var expectedFields = new TestPredicateFields();
+            var predicate = new ExistsPredicate<TestPredicateFields>(expectedFields);
+            Assert.AreSame(expectedFields, predicate.Fields);
+        }
+
+        [TestMethod]
+        public void MatchesPredicate_Constructor_SetsCaseSensitivity()
+        {
+            var fields = new TestPredicateFields();
+            var predicate = new ExistsPredicate<TestPredicateFields>(fields, isCaseSensitive: true);
+            Assert.IsTrue(predicate.IsCaseSensitive);
+        }
+
+        [TestMethod]
+        public void MatchesPredicate_Constructor_SetsExceptExpression()
+        {
+            const string expectedExceptRegex = "!$";
+
+            var fields = new TestPredicateFields();
+            var predicate = new ExistsPredicate<TestPredicateFields>(fields, exceptExpression: expectedExceptRegex);
+            Assert.AreEqual(expectedExceptRegex, predicate.ExceptExpression);
+        }
+
+        [TestMethod]
+        public void MatchesPredicate_Constructor_SetsXpathSelector()
+        {
+            var expectedXPathSelector = new XPathSelector("!$");
+
+            var fields = new TestPredicateFields();
+            var predicate = new ExistsPredicate<TestPredicateFields>(fields, xpath: expectedXPathSelector);
+            Assert.AreEqual(expectedXPathSelector, predicate.XPathSelector);
+        }
+
+        [TestMethod]
+        public void MatchesPredicate_Constructor_SetsJsonPathSelector()
+        {
+            var expectedJsonPathSelector = new JsonPathSelector("$..title");
+
+            var fields = new TestPredicateFields();
+            var predicate = new ExistsPredicate<TestPredicateFields>(fields, jsonpath: expectedJsonPathSelector);
+            Assert.AreEqual(expectedJsonPathSelector, predicate.JsonPathSelector);
+        }
+    }
+}

--- a/MbDotNet/Models/Predicates/ExistsPredicate.cs
+++ b/MbDotNet/Models/Predicates/ExistsPredicate.cs
@@ -1,0 +1,18 @@
+﻿using MbDotNet.Models.Predicates.Fields;
+using Newtonsoft.Json;
+
+namespace MbDotNet.Models.Predicates
+{
+    public class ExistsPredicate<T> : PredicateBase where T : PredicateFields
+    {
+        [JsonProperty("exists")]
+        public T Fields { get; private set; }
+
+        public ExistsPredicate(T fields, bool isCaseSensitive = false, string exceptExpression = null,
+                                    XPathSelector xpath = null, JsonPathSelector jsonpath = null)
+            : base(isCaseSensitive, exceptExpression, xpath, jsonpath)
+        {
+            Fields = fields;
+        }
+    }
+}


### PR DESCRIPTION
Exists predicate works like matches/equals/etc. with HttpPredicateFields. The difference as far as Mountebank is concerned, is that exists expects boolean values to indicate whether a parameter exists or not. E.g, if we apply an equals predicate on the request body as such:

```JSON
{
    "id": "1234",
    "content": {
        "title": "Hello World"
    }
}
```

Then the request body of an http request will need an `id` of '1234' and `content.title` of 'Hello World'.

If instead we used an exists predicate, it may look like:

```JSON
{
    "id": true,
    "content": {
        "title": true
    }
}
```

Which specifies that the request body of an http request must have `id` and `content.title` values regardless of what the values actually are. 