### PR TITLE
Support for SMTP imposters.

### DIFF
--- a/MbDotNet.Tests/Acceptance/ImposterTests.cs
+++ b/MbDotNet.Tests/Acceptance/ImposterTests.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Mail;
+using System.Net.Mime;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
@@ -64,12 +66,15 @@ namespace MbDotNet.Tests.Acceptance
         [TestMethod]
         public async Task CanCreateAndGetHttpsImposter()
         {
+            // Arrange
             const int port = 6000;
             var imposter = _client.CreateHttpsImposter(port);
 
+            // Act
             await _client.SubmitAsync(imposter);
-
             var retrievedImposter = await _client.GetHttpsImposterAsync(port);
+
+            // Assert
             Assert.IsNotNull(retrievedImposter);
         }
 
@@ -266,6 +271,58 @@ namespace MbDotNet.Tests.Acceptance
             Assert.AreNotEqual(string.Empty, receivedRequest.RequestFrom);
             Assert.AreEqual("text/xml; charset=utf-8", receivedRequest.Headers["Content-Type"]);
             Assert.AreEqual("75", receivedRequest.Headers["Content-Length"]);
+        }
+
+        [TestMethod]
+        public async Task CanVerifyCallsOnSmtpImposter()
+        {
+            // Arrange
+            const int port = 6000;
+            const string from = "sender@test.com";
+            const string to1 = "recipient1@test.com";
+            const string to2 = "recipient2@test.com";
+            const string subject = "Test Subject";
+            const string body = "Test Body";
+            const string attachmentContent1 = "Test Content1";
+            const string attachmentContent2 = "Test Content2";
+
+            var imposter = _client.CreateSmtpImposter(port, recordRequests: true);
+            await _client.SubmitAsync(imposter);
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress(from),
+                Subject = subject,
+                Body = body
+            };
+            mail.To.Add(to1);
+            mail.To.Add(to2);
+
+            var attachment1 = Attachment.CreateAttachmentFromString(attachmentContent1, new ContentType("text/plain"));
+            var attachment2 = Attachment.CreateAttachmentFromString(attachmentContent2, new ContentType("text/plain"));
+
+            mail.Attachments.Add(attachment1);
+            mail.Attachments.Add(attachment2);
+
+            var smtpClient = new SmtpClient("localhost")
+            {
+                Port = port
+            };
+
+            await smtpClient.SendMailAsync(mail);
+
+            // Act
+            var retrievedImposter = await _client.GetSmtpImposterAsync(port);
+
+            // Assert
+            Assert.AreEqual(1, retrievedImposter.NumberOfRequests);
+            Assert.AreEqual(from, retrievedImposter.Requests.First().EnvelopeFrom);
+            Assert.AreEqual(to1, retrievedImposter.Requests.First().EnvelopeTo.First());
+            Assert.AreEqual(to2, retrievedImposter.Requests.First().EnvelopeTo.Last());
+            Assert.AreEqual(subject, retrievedImposter.Requests.First().Subject);
+            Assert.AreEqual(body, retrievedImposter.Requests.First().Text);
+            Assert.AreEqual(attachmentContent1, Encoding.UTF8.GetString(retrievedImposter.Requests.First().Attachments.First().Content.Data));
+            Assert.AreEqual(attachmentContent2, Encoding.UTF8.GetString(retrievedImposter.Requests.First().Attachments.Last().Content.Data));
         }
 
         [TestMethod]

--- a/MbDotNet.Tests/Acceptance/ImposterTests.cs
+++ b/MbDotNet.Tests/Acceptance/ImposterTests.cs
@@ -122,6 +122,21 @@ namespace MbDotNet.Tests.Acceptance
         }
 
         [TestMethod]
+        public async Task CanCreateAndGetSmtpImposter()
+        {
+            const int port = 587;
+            const string name = "TestSmtp";
+
+            var imposter = _client.CreateSmtpImposter(port, name, true);
+
+            await _client.SubmitAsync(imposter);
+
+            var retrievedImposter = await _client.GetSmtpImposterAsync(port);
+            Assert.IsNotNull(retrievedImposter);
+            Assert.AreEqual(name, retrievedImposter.Name);
+        }
+
+        [TestMethod]
         public async Task CanCreateHttpProxyImposter()
         {
             const int sourceImposterPort = 6000;

--- a/MbDotNet.Tests/Acceptance/ImposterTests.cs
+++ b/MbDotNet.Tests/Acceptance/ImposterTests.cs
@@ -124,7 +124,7 @@ namespace MbDotNet.Tests.Acceptance
         [TestMethod]
         public async Task CanCreateAndGetSmtpImposter()
         {
-            const int port = 587;
+            const int port = 6000;
             const string name = "TestSmtp";
 
             var imposter = _client.CreateSmtpImposter(port, name, true);

--- a/MbDotNet.Tests/Acceptance/ImposterTests.cs
+++ b/MbDotNet.Tests/Acceptance/ImposterTests.cs
@@ -66,15 +66,13 @@ namespace MbDotNet.Tests.Acceptance
         [TestMethod]
         public async Task CanCreateAndGetHttpsImposter()
         {
-            // Arrange
             const int port = 6000;
             var imposter = _client.CreateHttpsImposter(port);
 
-            // Act
             await _client.SubmitAsync(imposter);
+
             var retrievedImposter = await _client.GetHttpsImposterAsync(port);
 
-            // Assert
             Assert.IsNotNull(retrievedImposter);
         }
 
@@ -276,7 +274,6 @@ namespace MbDotNet.Tests.Acceptance
         [TestMethod]
         public async Task CanVerifyCallsOnSmtpImposter()
         {
-            // Arrange
             const int port = 6000;
             const string from = "sender@test.com";
             const string to1 = "recipient1@test.com";
@@ -311,10 +308,8 @@ namespace MbDotNet.Tests.Acceptance
 
             await smtpClient.SendMailAsync(mail);
 
-            // Act
             var retrievedImposter = await _client.GetSmtpImposterAsync(port);
 
-            // Assert
             Assert.AreEqual(1, retrievedImposter.NumberOfRequests);
             Assert.AreEqual(from, retrievedImposter.Requests.First().EnvelopeFrom);
             Assert.AreEqual(to1, retrievedImposter.Requests.First().EnvelopeTo.First());

--- a/MbDotNet.Tests/Models/Imposters/SmtpImposterTests.cs
+++ b/MbDotNet.Tests/Models/Imposters/SmtpImposterTests.cs
@@ -1,0 +1,46 @@
+﻿using MbDotNet.Models.Imposters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Tests.Models.Imposters
+{
+    [TestClass, TestCategory("Unit")]
+    public class SmtpImposterTests
+    {
+        #region Constructor Tests
+
+        [TestMethod]
+        public void Constructor_SetsPort()
+        {
+            const int port = 123;
+            var imposter = new SmtpImposter(port, null);
+            Assert.AreEqual(port, imposter.Port);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsProtocol()
+        {
+            var imposter = new SmtpImposter(123, null);
+            Assert.AreEqual("smtp", imposter.Protocol);
+        }
+
+        [TestMethod]
+        public void Constructor_SetsName()
+        {
+            const string expectedName = "Service";
+            var imposter = new SmtpImposter(123, expectedName);
+            Assert.AreEqual(expectedName, imposter.Name);
+        }
+
+        [TestMethod]
+        public void Constructor_AllowsNullPort()
+        {
+            var imposter = new SmtpImposter(null, null);
+            Assert.AreEqual(default(int), imposter.Port);
+        }
+
+        #endregion
+    }
+}

--- a/MbDotNet/IClient.cs
+++ b/MbDotNet/IClient.cs
@@ -80,6 +80,25 @@ namespace MbDotNet
             bool recordRequests = false, TcpResponseFields defaultResponse = null);
 
         /// <summary>
+        /// Creates a new imposter on the specified port with the SMTP protocol. The Submit method
+        /// must be called on the client in order to submit the imposter to Mountebank. If the port
+        /// is blank, Mountebank will assign one which can be retrieved after Submit. Note that Mountebank does not yet support
+        /// stubs for SMTP imposters.
+        /// </summary>
+        /// <param name="port">
+        /// The port the imposter will be set up to receive requests on, or null to allow
+        /// Mountebank to set the port.
+        /// </param>
+        /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
+        /// <returns>The newly created imposter</returns>
+        SmtpImposter CreateSmtpImposter(int? port = null, string name = null, bool recordRequests = false);
+
+        /// <summary>
         /// Retrieves an HttpImposter along with information about requests made to that
         /// imposter if mountebank is running with the "--mock" flag.
         /// </summary>
@@ -108,6 +127,16 @@ namespace MbDotNet
         /// <exception cref="MbDotNet.Exceptions.ImposterNotFoundException">Thrown if no imposter was found on the specified port.</exception>
         /// <exception cref="MbDotNet.Exceptions.InvalidProtocolException">Thrown if the retrieved imposter was not an HTTP imposter</exception>
         Task<RetrievedHttpsImposter> GetHttpsImposterAsync(int port, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a SmtpImposter along with information about requests made to that
+        /// imposter if Mountebank is running with the "--mock" flag.
+        /// </summary>
+        /// <param name="port">The port number of the imposter to retrieve</param>
+        /// <returns>The retrieved imposter</returns>
+        /// <exception cref="MbDotNet.Exceptions.ImposterNotFoundException">Thrown if no imposter was found on the specified port.</exception>
+        /// <exception cref="MbDotNet.Exceptions.InvalidProtocolException">Thrown if the retrieved imposter was not an SMTP imposter</exception>
+        Task<RetrievedSmtpImposter> GetSmtpImposterAsync(int port, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a single imposter from mountebank. Will also remove the imposter from the collection

--- a/MbDotNet/IRequestProxy.cs
+++ b/MbDotNet/IRequestProxy.cs
@@ -13,6 +13,7 @@ namespace MbDotNet
         Task<RetrievedHttpImposter> GetHttpImposterAsync(int port, CancellationToken cancellationToken = default);
         Task<RetrievedTcpImposter> GetTcpImposterAsync(int port, CancellationToken cancellationToken = default);
         Task<RetrievedHttpsImposter> GetHttpsImposterAsync(int port, CancellationToken cancellationToken = default);
+        Task<RetrievedSmtpImposter> GetSmtpImposterAsync(int port, CancellationToken cancellationToken = default);
         Task DeleteSavedRequestsAsync(int port, CancellationToken cancellationToken = default);
     }
 }

--- a/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
+++ b/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace MbDotNet.Models.Imposters
 {
-    public class RetrievedSmtpImposter: RetrievedImposter<HttpRequest, HttpResponseFields>
+    public class RetrievedSmtpImposter: RetrievedImposter<SmtpRequest, HttpResponseFields>
     {
     }
 }

--- a/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
+++ b/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace MbDotNet.Models.Imposters
 {
-    public class RetrievedSmtpImposter: RetrievedImposter<SmtpRequest, HttpResponseFields>
+    public class RetrievedSmtpImposter: RetrievedImposter<SmtpRequest, SmtpResponseFields>
     {
     }
 }

--- a/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
+++ b/MbDotNet/Models/Imposters/RetrievedSmtpImposter.cs
@@ -1,0 +1,12 @@
+﻿using MbDotNet.Models.Requests;
+using MbDotNet.Models.Responses.Fields;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Imposters
+{
+    public class RetrievedSmtpImposter: RetrievedImposter<HttpRequest, HttpResponseFields>
+    {
+    }
+}

--- a/MbDotNet/Models/Imposters/SmtpImposter.cs
+++ b/MbDotNet/Models/Imposters/SmtpImposter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Imposters
+{
+    public class SmtpImposter: Imposter
+    {
+        public SmtpImposter(int? port, string name, bool recordRequests = false)
+            : base(port, Enums.Protocol.Smtp, name, recordRequests)
+        {
+        }
+    }
+}

--- a/MbDotNet/Models/Requests/EmailAddress.cs
+++ b/MbDotNet/Models/Requests/EmailAddress.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Requests
+{
+    public class EmailAddress
+    {
+        [JsonProperty("address")]
+        public string Address { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/MbDotNet/Models/Requests/EmailAttachment.cs
+++ b/MbDotNet/Models/Requests/EmailAttachment.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Requests
+{
+    public class EmailAttachment
+    {
+        [JsonProperty("type")]
+        public string Type { get; internal set; }
+
+        [JsonProperty("contentType")]
+        public string ContentType { get; internal set; }
+
+        [JsonProperty("content")]
+        public EmailContent Content { get; internal set; }
+
+        [JsonProperty("contentDisposition")]
+        public string ContentDisposition { get; internal set; }
+
+        [JsonProperty("size")]
+        public long Size { get; internal set; }
+    }
+}

--- a/MbDotNet/Models/Requests/EmailContent.cs
+++ b/MbDotNet/Models/Requests/EmailContent.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Requests
+{
+    public class EmailContent
+    {
+        [JsonProperty("type")]
+        public string Type { get; internal set; }
+
+        [JsonProperty("data")]
+        public byte[] Data { get; internal set; }
+    }
+}

--- a/MbDotNet/Models/Requests/SmtpRequest.cs
+++ b/MbDotNet/Models/Requests/SmtpRequest.cs
@@ -11,31 +11,28 @@ namespace MbDotNet.Models.Requests
         public string EnvelopeFrom { get; internal set; }
 
         [JsonProperty("envelopeTo")]
-        public string EnvelopeTo { get; internal set; }
+        public IList<string> EnvelopeTo { get; internal set; }
 
         [JsonProperty("from")]
-        public string From { get; internal set; }
+        public EmailAddress From { get; internal set; }
 
         [JsonProperty("to")]
-        public IList<string> To { get; internal set; }
+        public IList<EmailAddress> To { get; internal set; }
 
         [JsonProperty("cc")]
-        public IList<string> Cc { get; internal set; }
+        public IList<EmailAddress> Cc { get; internal set; }
 
         [JsonProperty("bcc")]
-        public IList<string> Bcc { get; internal set; }
+        public IList<EmailAddress> Bcc { get; internal set; }
 
         [JsonProperty("subject")]
-        public IList<string> Subject { get; internal set; }
+        public string Subject { get; internal set; }
 
         [JsonProperty("priority")]
         public string Priority { get; internal set; }
 
-        [JsonProperty("references")]
-        public IList<string> References { get; internal set; }
-
         [JsonProperty("inReplyTo")]
-        public IList<string> InReplyTo { get; internal set; }
+        public IList<EmailAddress> InReplyTo { get; internal set; }
 
         [JsonProperty("text")]
         public string Text { get; internal set; }
@@ -44,6 +41,6 @@ namespace MbDotNet.Models.Requests
         public string Html { get; internal set; }
 
         [JsonProperty("attachments")]
-        public IList<string> Attachments { get; internal set; }
+        public IList<EmailAttachment> Attachments { get; internal set; }
     }
 }

--- a/MbDotNet/Models/Requests/SmtpRequest.cs
+++ b/MbDotNet/Models/Requests/SmtpRequest.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Requests
+{
+    public class SmtpRequest: Request
+    {
+        [JsonProperty("envelopeFrom")]
+        public string EnvelopeFrom { get; internal set; }
+
+        [JsonProperty("envelopeTo")]
+        public string EnvelopeTo { get; internal set; }
+
+        [JsonProperty("from")]
+        public string From { get; internal set; }
+
+        [JsonProperty("to")]
+        public IList<string> To { get; internal set; }
+
+        [JsonProperty("cc")]
+        public IList<string> Cc { get; internal set; }
+
+        [JsonProperty("bcc")]
+        public IList<string> Bcc { get; internal set; }
+
+        [JsonProperty("subject")]
+        public IList<string> Subject { get; internal set; }
+
+        [JsonProperty("priority")]
+        public string Priority { get; internal set; }
+
+        [JsonProperty("references")]
+        public IList<string> References { get; internal set; }
+
+        [JsonProperty("inReplyTo")]
+        public IList<string> InReplyTo { get; internal set; }
+
+        [JsonProperty("text")]
+        public string Text { get; internal set; }
+
+        [JsonProperty("html")]
+        public string Html { get; internal set; }
+
+        [JsonProperty("attachments")]
+        public IList<string> Attachments { get; internal set; }
+    }
+}

--- a/MbDotNet/Models/Responses/Fields/SmtpResponseFields.cs
+++ b/MbDotNet/Models/Responses/Fields/SmtpResponseFields.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MbDotNet.Models.Responses.Fields
+{
+    public class SmtpResponseFields: ResponseFields
+    {
+    }
+}

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -108,6 +108,28 @@ namespace MbDotNet
         }
 
         /// <summary>
+        /// Creates a new imposter on the specified port with the SMTP protocol. The Submit method
+        /// must be called on the client in order to submit the imposter to Mountebank. If the port
+        /// is blank, Mountebank will assign one which can be retrieved after Submit. Note that Mountebank does not yet support
+        /// stubs for SMTP imposters.
+        /// </summary>
+        /// <param name="port">
+        /// The port the imposter will be set up to receive requests on, or null to allow
+        /// Mountebank to set the port.
+        /// </param>
+        /// <param name="name">The name the imposter will recieve, useful for debugging/logging purposes</param>
+        /// <param name="recordRequests">
+        /// Enables recording requests to use the imposter as a mock. See
+        /// <see href="http://www.mbtest.org/docs/api/mocks">here</see> for more details on Mountebank
+        /// verification.
+        /// </param>
+        /// <returns>The newly created imposter</returns>
+        public SmtpImposter CreateSmtpImposter(int? port = null, string name = null, bool recordRequests = false)
+        {
+            return new SmtpImposter(port, name, recordRequests);
+        }
+
+        /// <summary>
         /// Retrieves an HttpImposter along with information about requests made to that
         /// imposter if mountebank is running with the "--mock" flag.
         /// </summary>
@@ -154,6 +176,23 @@ namespace MbDotNet
             var imposter = await _requestProxy.GetHttpsImposterAsync(port, cancellationToken).ConfigureAwait(false);
 
             ValidateRetrievedImposterProtocol(imposter, Protocol.Https);
+
+            return imposter;
+        }
+
+        /// <summary>
+        /// Retrieves a SmtpImposter along with information about requests made to that
+        /// imposter if Mountebank is running with the "--mock" flag.
+        /// </summary>
+        /// <param name="port">The port number of the imposter to retrieve</param>
+        /// <returns>The retrieved imposter</returns>
+        /// <exception cref="MbDotNet.Exceptions.ImposterNotFoundException">Thrown if no imposter was found on the specified port.</exception>
+        /// <exception cref="MbDotNet.Exceptions.InvalidProtocolException">Thrown if the retrieved imposter was not an SMTP imposter</exception>
+        public async Task<RetrievedSmtpImposter> GetSmtpImposterAsync(int port, CancellationToken cancellationToken = default)
+        {
+            var imposter = await _requestProxy.GetSmtpImposterAsync(port, cancellationToken).ConfigureAwait(false);
+
+            ValidateRetrievedImposterProtocol(imposter, Protocol.Smtp);
 
             return imposter;
         }

--- a/MbDotNet/MountebankRequestProxy.cs
+++ b/MbDotNet/MountebankRequestProxy.cs
@@ -98,6 +98,12 @@ namespace MbDotNet
                 .ConfigureAwait(false);
         }
 
+        public async Task<RetrievedSmtpImposter> GetSmtpImposterAsync(int port, CancellationToken cancellationToken = default)
+        {
+            return await GetImposterAsync<RetrievedSmtpImposter>(port, cancellationToken)
+               .ConfigureAwait(false);
+        }
+
         public async Task DeleteSavedRequestsAsync(int port, CancellationToken cancellationToken = default)
         {
             using (var response = await _httpClient.DeleteAsync($"{ImpostersResource}/{port}/savedRequests", cancellationToken).ConfigureAwait(false))


### PR DESCRIPTION
Note: Mountebank doesn't currently support stubs for SMTP imposters. (only mock verification)