### PR TITLE
GenerateDocumentationFile added to MbDotNet.csproj

### DIFF
--- a/MbDotNet/MbDotNet.csproj
+++ b/MbDotNet/MbDotNet.csproj
@@ -9,6 +9,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <FileVersion>5.0.0.0</FileVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet Metadata-->
     <Version>5.0.0-rc7</Version>


### PR DESCRIPTION
GenerateDocumentationFile added to csproj to allow generation of intellisense documentation in Visual Studio when using the NuGet package. The XML documentation file is generated and should be added to the NuGet by the Pack command to be able to read documentation while using the package.