### PR TITLE
Add ConfigureAwait(false) where missing

### DIFF
--- a/MbDotNet/HttpClientWrapper.cs
+++ b/MbDotNet/HttpClientWrapper.cs
@@ -43,7 +43,7 @@ namespace MbDotNet
 			GC.SuppressFinalize(this);
 		}
 
-		protected virtual void Dispose(bool disposing)
+		private void Dispose(bool disposing)
 		{
 			if (disposing)
 			{

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -43,51 +43,51 @@ namespace MbDotNet
 
 		/// <inheritdoc />
 		public async Task<HttpImposter> CreateHttpImposterAsync(HttpImposter imposter, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken);
+			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<HttpImposter> CreateHttpImposterAsync(int? port, string name, Action<HttpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new HttpImposter(port, name, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new HttpImposter(port, name, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<HttpImposter> CreateHttpImposterAsync(int? port, Action<HttpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new HttpImposter(port, null, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new HttpImposter(port, null, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<HttpsImposter> CreateHttpsImposterAsync(HttpsImposter imposter, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken);
+			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<HttpsImposter> CreateHttpsImposterAsync(int? port, string name, Action<HttpsImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new HttpsImposter(port, name, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new HttpsImposter(port, name, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<HttpsImposter> CreateHttpsImposterAsync(int? port, Action<HttpsImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new HttpsImposter(port, null, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new HttpsImposter(port, null, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<TcpImposter> CreateTcpImposterAsync(TcpImposter imposter, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken);
+			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<TcpImposter> CreateTcpImposterAsync(int? port, string name, Action<TcpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new TcpImposter(port, name, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new TcpImposter(port, name, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<TcpImposter> CreateTcpImposterAsync(int? port, Action<TcpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new TcpImposter(port, null, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new TcpImposter(port, null, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<SmtpImposter> CreateSmtpImposterAsync(SmtpImposter imposter, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken);
+			await ConfigureAndCreateImposter(imposter, _ => { }, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<SmtpImposter> CreateSmtpImposterAsync(int? port, string name, Action<SmtpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new SmtpImposter(port, name, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new SmtpImposter(port, name, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<SmtpImposter> CreateSmtpImposterAsync(int? port, Action<SmtpImposter> imposterConfigurator, CancellationToken cancellationToken = default) =>
-			await ConfigureAndCreateImposter(new SmtpImposter(port, null, null), imposterConfigurator, cancellationToken);
+			await ConfigureAndCreateImposter(new SmtpImposter(port, null, null), imposterConfigurator, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task<IEnumerable<SimpleRetrievedImposter>> GetImpostersAsync(CancellationToken cancellationToken = default)
@@ -162,62 +162,62 @@ namespace MbDotNet
 		/// <inheritdoc />
 		public async Task ReplaceHttpImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken);
+			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task ReplaceHttpsImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken);
+			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task ReplaceTcpImposterStubsAsync(int port, ICollection<TcpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken);
+			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task ReplaceHttpImposterStubAsync(int port, HttpStub replacementStub, int stubIndex,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken);
+			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task ReplaceHttpsImposterStubAsync(int port, HttpStub replacementStub, int stubIndex,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken);
+			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task ReplaceTcpImposterStubAsync(int port, TcpStub replacementStub, int stubIndex,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken);
+			await _requestProxy.ReplaceStubAsync(port, replacementStub, stubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task AddHttpImposterStubAsync(int port, HttpStub newStub, int? newStubIndex = null,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken);
+			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task AddHttpsImposterStubAsync(int port, HttpStub newStub, int? newStubIndex = null,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken);
+			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task AddTcpImposterStubAsync(int port, TcpStub newStub, int? newStubIndex = null,
 			CancellationToken cancellationToken = default) =>
-			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken);
+			await _requestProxy.AddStubAsync(port, newStub, newStubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task RemoveStubAsync(int port, int stubIndex, CancellationToken cancellationToken = default) =>
-			await _requestProxy.RemoveStubAsync(port, stubIndex, cancellationToken);
+			await _requestProxy.RemoveStubAsync(port, stubIndex, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
 		public async Task DeleteSavedRequestsAsync(int port, CancellationToken cancellationToken = default)
 		{
-			await _requestProxy.DeleteSavedRequestsAsync(port, cancellationToken);
+			await _requestProxy.DeleteSavedRequestsAsync(port, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <inheritdoc />
 		public async Task<Config> GetConfigAsync(CancellationToken cancellationToken = default)
 		{
-			return await _requestProxy.GetConfigAsync(cancellationToken);
+			return await _requestProxy.GetConfigAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <inheritdoc />

--- a/MbDotNet/MountebankRequestProxy.cs
+++ b/MbDotNet/MountebankRequestProxy.cs
@@ -145,7 +145,8 @@ namespace MbDotNet
 		{
 			using (var response = await _httpClient.GetAsync("", cancellationToken).ConfigureAwait(false))
 			{
-				await HandleResponse(response, HttpStatusCode.OK, $"Failed to get the entry hypermedia");
+				await HandleResponse(response, HttpStatusCode.OK, $"Failed to get the entry hypermedia")
+					.ConfigureAwait(false);
 				var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				return JsonConvert.DeserializeObject<Home>(content);
 			}
@@ -155,7 +156,7 @@ namespace MbDotNet
 		{
 			using (var response = await _httpClient.GetAsync("logs", cancellationToken).ConfigureAwait(false))
 			{
-				await HandleResponse(response, HttpStatusCode.OK, $"Failed to get the logs");
+				await HandleResponse(response, HttpStatusCode.OK, $"Failed to get the logs").ConfigureAwait(false);
 				var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				var logs = JObject.Parse(content)["logs"]?.ToString();
 				if (logs == null)
@@ -168,7 +169,7 @@ namespace MbDotNet
 		{
 			using (var response = await _httpClient.GetAsync("imposters", cancellationToken).ConfigureAwait(false))
 			{
-				await HandleResponse(response, HttpStatusCode.OK, $"Failed to retrieve the list of imposters");
+				await HandleResponse(response, HttpStatusCode.OK, $"Failed to retrieve the list of imposters").ConfigureAwait(false);
 				var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 				var imposters = JObject.Parse(content)["imposters"]?.ToString();
 				if (imposters == null)
@@ -222,7 +223,7 @@ namespace MbDotNet
 			}
 		}
 
-		private async Task HandleResponse(HttpResponseMessage response, HttpStatusCode expectedStatusCode,
+		private static async Task HandleResponse(HttpResponseMessage response, HttpStatusCode expectedStatusCode,
 			string failureErrorMessage, Func<string, Exception> exceptionFactory = null)
 		{
 			if (exceptionFactory == null)


### PR DESCRIPTION
It is best practice to use `ConfigureAwait(false)` on any async calls in general purpose library code:
https://devblogs.microsoft.com/dotnet/configureawait-faq/

I was already doing this in most places, but some new code was missing it.