### PR TITLE
Update collection types to match use case

### DIFF
--- a/MbDotNet.Tests/Acceptance/ImposterTests.cs
+++ b/MbDotNet.Tests/Acceptance/ImposterTests.cs
@@ -635,13 +635,13 @@ namespace MbDotNet.Tests.Acceptance
 
 			var retrievedImposter = await _client.GetHttpImposterAsync(port);
 
-			Assert.AreEqual(retrievedImposter.Requests.Length, 1);
+			Assert.AreEqual(retrievedImposter.Requests.Count, 1);
 
 			await _client.DeleteSavedRequestsAsync(port);
 
 			retrievedImposter = await _client.GetHttpImposterAsync(port);
 
-			Assert.AreEqual(retrievedImposter.Requests.Length, 0);
+			Assert.AreEqual(retrievedImposter.Requests.Count, 0);
 		}
 
 		[TestMethod]

--- a/MbDotNet.Tests/Models/Stubs/HttpStubTests.cs
+++ b/MbDotNet.Tests/Models/Stubs/HttpStubTests.cs
@@ -316,6 +316,7 @@ namespace MbDotNet.Tests.Models.Stubs
 
 			var proxyResponse = stub.Responses.First() as ProxyResponse<ProxyResponseFields<HttpBooleanPredicateFields>>;
 
+			Assert.IsNotNull(proxyResponse);
 			Assert.AreEqual(proxyToUrl, proxyResponse.Fields.To);
 			Assert.AreEqual(proxyModeToUse, proxyResponse.Fields.Mode);
 			Assert.AreEqual(proxyGeneratorPredicate, proxyResponse.Fields.PredicateGenerators.First());
@@ -337,7 +338,7 @@ namespace MbDotNet.Tests.Models.Stubs
 			});
 
 			var proxyToUrl = new Uri("http://someTestDestination.com");
-			var proxyModeToUse = ProxyMode.ProxyTransparent;
+			const ProxyMode proxyModeToUse = ProxyMode.ProxyTransparent;
 
 			var stub = new HttpStub();
 			stub.On(predicateInvokingProxyStub)
@@ -345,6 +346,7 @@ namespace MbDotNet.Tests.Models.Stubs
 
 			var proxyResponse = stub.Responses.First() as ProxyResponse<ProxyResponseFields<HttpPredicateFields>>;
 
+			Assert.IsNotNull(proxyResponse);
 			Assert.AreEqual(proxyToUrl, proxyResponse.Fields.To);
 			Assert.AreEqual(proxyModeToUse, proxyResponse.Fields.Mode);
 			Assert.AreEqual(proxyGeneratorPredicate, proxyResponse.Fields.PredicateGenerators.First());

--- a/MbDotNet.Tests/Models/Stubs/TcpStubTests.cs
+++ b/MbDotNet.Tests/Models/Stubs/TcpStubTests.cs
@@ -143,7 +143,7 @@ namespace MbDotNet.Tests.Models.Stubs
 			});
 
 			var proxyToUrl = new Uri("tcp://someTestDestination.com");
-			var proxyModeToUse = ProxyMode.ProxyTransparent;
+			const ProxyMode proxyModeToUse = ProxyMode.ProxyTransparent;
 
 			var stub = new TcpStub();
 			stub.On(predicateInvokingProxyStub)
@@ -151,6 +151,7 @@ namespace MbDotNet.Tests.Models.Stubs
 
 			var proxyResponse = stub.Responses.First() as ProxyResponse<ProxyResponseFields<TcpBooleanPredicateFields>>;
 
+			Assert.IsNotNull(proxyResponse);
 			Assert.AreEqual(proxyToUrl, proxyResponse.Fields.To);
 			Assert.AreEqual(proxyModeToUse, proxyResponse.Fields.Mode);
 			Assert.AreEqual(proxyGeneratorPredicate, proxyResponse.Fields.PredicateGenerators.First());
@@ -170,7 +171,7 @@ namespace MbDotNet.Tests.Models.Stubs
 			});
 
 			var proxyToUrl = new Uri("tcp://someTestDestination.com");
-			var proxyModeToUse = ProxyMode.ProxyTransparent;
+			const ProxyMode proxyModeToUse = ProxyMode.ProxyTransparent;
 
 			var stub = new TcpStub();
 			stub.On(predicateInvokingProxyStub)
@@ -178,6 +179,7 @@ namespace MbDotNet.Tests.Models.Stubs
 
 			var proxyResponse = stub.Responses.First() as ProxyResponse<ProxyResponseFields<TcpPredicateFields>>;
 
+			Assert.IsNotNull(proxyResponse);
 			Assert.AreEqual(proxyToUrl, proxyResponse.Fields.To);
 			Assert.AreEqual(proxyModeToUse, proxyResponse.Fields.Mode);
 			Assert.AreEqual(proxyGeneratorPredicate, proxyResponse.Fields.PredicateGenerators.First());

--- a/MbDotNet.sln.DotSettings
+++ b/MbDotNet.sln.DotSettings
@@ -1,3 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CORS/@EntryIndexedValue">CORS</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PEM/@EntryIndexedValue">PEM</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PEM/@EntryIndexedValue">PEM</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=proxyalways/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=proxyonce/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=proxytransparent/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/MbDotNet/IClient.cs
+++ b/MbDotNet/IClient.cs
@@ -256,7 +256,7 @@ namespace MbDotNet
 		/// <param name="port">The port of the imposter being updated</param>
 		/// <param name="replacementStubs">The stubs that should replace the existing stubs</param>
 		/// <param name="cancellationToken"></param>
-		Task ReplaceHttpImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs, CancellationToken cancellationToken = default);
+		Task ReplaceHttpImposterStubsAsync(int port, IEnumerable<HttpStub> replacementStubs, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Replaces all stubs on an imposter with the replacement stubs.
@@ -264,7 +264,7 @@ namespace MbDotNet
 		/// <param name="port">The port of the imposter being updated</param>
 		/// <param name="replacementStubs">The stubs that should replace the existing stubs</param>
 		/// <param name="cancellationToken"></param>
-		Task ReplaceHttpsImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs, CancellationToken cancellationToken = default);
+		Task ReplaceHttpsImposterStubsAsync(int port, IEnumerable<HttpStub> replacementStubs, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Replaces all stubs on an imposter with the replacement stubs.
@@ -272,7 +272,7 @@ namespace MbDotNet
 		/// <param name="port">The port of the imposter being updated</param>
 		/// <param name="replacementStubs">The stubs that should replace the existing stubs</param>
 		/// <param name="cancellationToken"></param>
-		Task ReplaceTcpImposterStubsAsync(int port, ICollection<TcpStub> replacementStubs, CancellationToken cancellationToken = default);
+		Task ReplaceTcpImposterStubsAsync(int port, IEnumerable<TcpStub> replacementStubs, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Replaces a single stub on an imposter with the replacement stub. The stub to replace is specified by the index.

--- a/MbDotNet/IRequestProxy.cs
+++ b/MbDotNet/IRequestProxy.cs
@@ -13,7 +13,7 @@ namespace MbDotNet
 		Task DeleteAllImpostersAsync(CancellationToken cancellationToken = default);
 		Task DeleteImposterAsync(int port, CancellationToken cancellationToken = default);
 		Task CreateImposterAsync(Imposter imposter, CancellationToken cancellationToken = default);
-		Task ReplaceStubsAsync<T>(int port, ICollection<T> replacementStubs, CancellationToken cancellationToken = default) where T: Stub;
+		Task ReplaceStubsAsync<T>(int port, IEnumerable<T> replacementStubs, CancellationToken cancellationToken = default) where T: Stub;
 		Task ReplaceStubAsync<T>(int port, T newStub, int stubIndex, CancellationToken cancellationToken = default);
 		Task AddStubAsync<T>(int port, T newStub, int? newStubIndex, CancellationToken cancellationToken = default);
 		Task RemoveStubAsync(int port, int stubIndex, CancellationToken cancellationToken = default);

--- a/MbDotNet/Models/Imposters/HttpImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpImposter.cs
@@ -14,7 +14,7 @@ namespace MbDotNet.Models.Imposters
 		/// The stubs defined for this imposter
 		/// </summary>
 		[JsonProperty("stubs")]
-		public ICollection<HttpStub> Stubs { get; private set; }
+		public IList<HttpStub> Stubs { get; private set; }
 
 		/// <inheritdoc />
 		[JsonProperty("defaultResponse")]

--- a/MbDotNet/Models/Imposters/HttpsImposter.cs
+++ b/MbDotNet/Models/Imposters/HttpsImposter.cs
@@ -14,7 +14,7 @@ namespace MbDotNet.Models.Imposters
 	{
 		/// <inheritdoc />
 		[JsonProperty("stubs")]
-		public ICollection<HttpStub> Stubs { get; private set; }
+		public IList<HttpStub> Stubs { get; private set; }
 
 		private static bool IsPEMFormatted(string value)
 			=> Regex.IsMatch(value, @"-----BEGIN CERTIFICATE-----[\S\s]*-----END CERTIFICATE-----");

--- a/MbDotNet/Models/Imposters/RetrievedImposter.cs
+++ b/MbDotNet/Models/Imposters/RetrievedImposter.cs
@@ -43,13 +43,13 @@ namespace MbDotNet.Models.Imposters
 		/// The requests that have been made to this imposter
 		/// </summary>
 		[JsonProperty("requests")]
-		public TRequest[] Requests { get; internal set; }
+		public IReadOnlyList<TRequest> Requests { get; internal set; }
 
 		/// <summary>
 		/// A set of behaviors used to generate a response for an imposter
 		/// </summary>
 		[JsonProperty("stubs")]
-		public ICollection<RetrievedStub<TRequest, TResponseFields>> Stubs { get; internal set; }
+		public IReadOnlyList<RetrievedStub<TRequest, TResponseFields>> Stubs { get; internal set; }
 
 		/// <summary>
 		/// Optional default response that imposter sends back if no predicate matches a request

--- a/MbDotNet/Models/Imposters/TcpImposter.cs
+++ b/MbDotNet/Models/Imposters/TcpImposter.cs
@@ -13,7 +13,7 @@ namespace MbDotNet.Models.Imposters
 	{
 		/// <inheritdoc />
 		[JsonProperty("stubs")]
-		public ICollection<TcpStub> Stubs { get; private set; }
+		public IList<TcpStub> Stubs { get; private set; }
 
 		[JsonProperty("mode")]
 		internal string ModeAsText;

--- a/MbDotNet/Models/Requests/SmtpRequest.cs
+++ b/MbDotNet/Models/Requests/SmtpRequest.cs
@@ -20,7 +20,7 @@ namespace MbDotNet.Models.Requests
 		/// The address sent using the RCPT command
 		/// </summary>
 		[JsonProperty("envelopeTo")]
-		public IList<string> EnvelopeTo { get; internal set; }
+		public IReadOnlyList<string> EnvelopeTo { get; internal set; }
 
 		/// <summary>
 		/// The sender of the message
@@ -32,19 +32,19 @@ namespace MbDotNet.Models.Requests
 		/// The recipients of the message
 		/// </summary>
 		[JsonProperty("to")]
-		public IList<EmailAddress> To { get; internal set; }
+		public IReadOnlyList<EmailAddress> To { get; internal set; }
 
 		/// <summary>
 		/// The CC recipients of the message
 		/// </summary>
 		[JsonProperty("cc")]
-		public IList<EmailAddress> Cc { get; internal set; }
+		public IReadOnlyList<EmailAddress> Cc { get; internal set; }
 
 		/// <summary>
 		/// The BCC recipients of the message
 		/// </summary>
 		[JsonProperty("bcc")]
-		public IList<EmailAddress> Bcc { get; internal set; }
+		public IReadOnlyList<EmailAddress> Bcc { get; internal set; }
 
 		/// <summary>
 		/// The subject of the message
@@ -62,7 +62,7 @@ namespace MbDotNet.Models.Requests
 		/// The in reply to of the message
 		/// </summary>
 		[JsonProperty("inReplyTo")]
-		public IList<EmailAddress> InReplyTo { get; internal set; }
+		public IReadOnlyList<EmailAddress> InReplyTo { get; internal set; }
 
 		/// <summary>
 		/// The text-only message
@@ -80,6 +80,6 @@ namespace MbDotNet.Models.Requests
 		/// The message attachments
 		/// </summary>
 		[JsonProperty("attachments")]
-		public IList<EmailAttachment> Attachments { get; internal set; }
+		public IReadOnlyList<EmailAttachment> Attachments { get; internal set; }
 	}
 }

--- a/MbDotNet/Models/Responses/Fields/ProxyResponseFields.cs
+++ b/MbDotNet/Models/Responses/Fields/ProxyResponseFields.cs
@@ -32,6 +32,6 @@ namespace MbDotNet.Models.Responses.Fields
 		/// An array of objects that defines how the predicates for new stubs are created
 		/// </summary>
 		[JsonProperty("predicateGenerators", NullValueHandling = NullValueHandling.Ignore)]
-		public IList<MatchesPredicate<T>> PredicateGenerators { get; set; }
+		public IEnumerable<MatchesPredicate<T>> PredicateGenerators { get; set; }
 	}
 }

--- a/MbDotNet/Models/Responses/Fields/ProxyResponseFields.cs
+++ b/MbDotNet/Models/Responses/Fields/ProxyResponseFields.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using MbDotNet.Enums;
 using MbDotNet.Models.Predicates;
 using MbDotNet.Models.Predicates.Fields;
@@ -32,6 +31,6 @@ namespace MbDotNet.Models.Responses.Fields
 		/// An array of objects that defines how the predicates for new stubs are created
 		/// </summary>
 		[JsonProperty("predicateGenerators", NullValueHandling = NullValueHandling.Ignore)]
-		public IEnumerable<MatchesPredicate<T>> PredicateGenerators { get; set; }
+		public IList<MatchesPredicate<T>> PredicateGenerators { get; set; }
 	}
 }

--- a/MbDotNet/Models/Stubs/HttpStub.cs
+++ b/MbDotNet/Models/Stubs/HttpStub.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Xml;
@@ -100,9 +101,9 @@ namespace MbDotNet.Models.Stubs
 		/// <param name="response">Byte array representing binary stream.</param>
 		/// <param name="contentType">Content type</param>
 		/// <returns>The stub that the response was added to</returns>
-		public HttpStub ReturnsBinary(HttpStatusCode statusCode, byte[] response, string contentType)
+		public HttpStub ReturnsBinary(HttpStatusCode statusCode, IEnumerable<byte> response, string contentType)
 		{
-			var convertedBase64Bytes = Convert.ToBase64String(response);
+			var convertedBase64Bytes = Convert.ToBase64String(response.ToArray());
 
 			return Returns(statusCode, new Dictionary<string, object> { { "Content-Type", contentType } }, convertedBase64Bytes, "binary");
 		}
@@ -161,10 +162,10 @@ namespace MbDotNet.Models.Stubs
 		/// </summary>
 		/// <param name="to">endpoint address to proxy to</param>
 		/// <param name="proxyMode">proxyalways, proxyonce or proxytransparent</param>
-		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
+		/// <param name="predicateGenerators">list of predicates that a proxy response will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public HttpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
-			IList<MatchesPredicate<HttpPredicateFields>> predicateGenerators)
+			IEnumerable<MatchesPredicate<HttpPredicateFields>> predicateGenerators)
 		{
 			var fields = new ProxyResponseFields<HttpPredicateFields>
 			{
@@ -183,10 +184,10 @@ namespace MbDotNet.Models.Stubs
 		/// </summary>
 		/// <param name="to">endpoint address to proxy to</param>
 		/// <param name="proxyMode">proxyalways, proxyonce or proxytransparent</param>
-		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
+		/// <param name="predicateGenerators">list of predicates that a proxy response will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public HttpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
-			IList<MatchesPredicate<HttpBooleanPredicateFields>> predicateGenerators)
+			IEnumerable<MatchesPredicate<HttpBooleanPredicateFields>> predicateGenerators)
 		{
 			var fields = new ProxyResponseFields<HttpBooleanPredicateFields>
 			{

--- a/MbDotNet/Models/Stubs/HttpStub.cs
+++ b/MbDotNet/Models/Stubs/HttpStub.cs
@@ -171,7 +171,7 @@ namespace MbDotNet.Models.Stubs
 			{
 				To = to,
 				Mode = proxyMode,
-				PredicateGenerators = predicateGenerators
+				PredicateGenerators = predicateGenerators.ToList()
 			};
 
 			var response = new ProxyResponse<ProxyResponseFields<HttpPredicateFields>>(fields);
@@ -193,7 +193,7 @@ namespace MbDotNet.Models.Stubs
 			{
 				To = to,
 				Mode = proxyMode,
-				PredicateGenerators = predicateGenerators
+				PredicateGenerators = predicateGenerators.ToList()
 			};
 
 			var response = new ProxyResponse<ProxyResponseFields<HttpBooleanPredicateFields>>(fields);

--- a/MbDotNet/Models/Stubs/IWithStubs.cs
+++ b/MbDotNet/Models/Stubs/IWithStubs.cs
@@ -11,7 +11,7 @@ namespace MbDotNet.Models.Stubs
 		/// <summary>
 		/// The configured stubs
 		/// </summary>
-		ICollection<TStub> Stubs { get; }
+		IList<TStub> Stubs { get; }
 
 		/// <summary>
 		/// Adds an empty stub

--- a/MbDotNet/Models/Stubs/RetrievedStub.cs
+++ b/MbDotNet/Models/Stubs/RetrievedStub.cs
@@ -19,7 +19,7 @@ namespace MbDotNet.Models.Stubs
 		/// An collection of all activity by this stub.
 		/// </summary>
 		[JsonProperty("matches", NullValueHandling = NullValueHandling.Ignore)]
-		public ICollection<Match<TRequest, TResponseFields>> Matches { get; set; }
+		public IReadOnlyList<Match<TRequest, TResponseFields>> Matches { get; set; }
 
 		/// <summary>
 		/// Create a new RetrievedStub instance

--- a/MbDotNet/Models/Stubs/Stub.cs
+++ b/MbDotNet/Models/Stubs/Stub.cs
@@ -14,13 +14,13 @@ namespace MbDotNet.Models.Stubs
 		/// A collection of all of the responses set up on this stub.
 		/// </summary>
 		[JsonProperty("predicates", NullValueHandling = NullValueHandling.Ignore)]
-		public ICollection<Predicate> Predicates { get; set; }
+		public IList<Predicate> Predicates { get; set; }
 
 		/// <summary>
 		/// A collection of all of the predicates set up on this stub.
 		/// </summary>
 		[JsonProperty("responses", NullValueHandling = NullValueHandling.Ignore)]
-		public ICollection<Response> Responses { get; set; }
+		public IList<Response> Responses { get; set; }
 
 		/// <summary>
 		/// Create a new StubBase instance

--- a/MbDotNet/Models/Stubs/TcpStub.cs
+++ b/MbDotNet/Models/Stubs/TcpStub.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MbDotNet.Enums;
 using MbDotNet.Models.Predicates;
 using MbDotNet.Models.Predicates.Fields;
@@ -89,7 +90,7 @@ namespace MbDotNet.Models.Stubs
 		/// </summary>
 		/// <param name="to">endpoint address to proxy to</param>
 		/// <param name="proxyMode">proxyalways, proxyonce or proxytransparent</param>
-		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
+		/// <param name="predicateGenerators">list of predicates that a proxy response will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public TcpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
 			IEnumerable<MatchesPredicate<TcpPredicateFields>> predicateGenerators)
@@ -98,7 +99,7 @@ namespace MbDotNet.Models.Stubs
 			{
 				To = to,
 				Mode = proxyMode,
-				PredicateGenerators = predicateGenerators
+				PredicateGenerators = predicateGenerators.ToList()
 			};
 
 			var response = new ProxyResponse<ProxyResponseFields<TcpPredicateFields>>(fields);
@@ -111,7 +112,7 @@ namespace MbDotNet.Models.Stubs
 		/// </summary>
 		/// <param name="to">endpoint address to proxy to</param>
 		/// <param name="proxyMode">proxyalways, proxyonce or proxytransparent</param>
-		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
+		/// <param name="predicateGenerators">list of predicates that a proxy response will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public TcpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
 			IEnumerable<MatchesPredicate<TcpBooleanPredicateFields>> predicateGenerators)
@@ -120,7 +121,7 @@ namespace MbDotNet.Models.Stubs
 			{
 				To = to,
 				Mode = proxyMode,
-				PredicateGenerators = predicateGenerators
+				PredicateGenerators = predicateGenerators.ToList()
 			};
 
 			var response = new ProxyResponse<ProxyResponseFields<TcpBooleanPredicateFields>>(fields);

--- a/MbDotNet/Models/Stubs/TcpStub.cs
+++ b/MbDotNet/Models/Stubs/TcpStub.cs
@@ -92,7 +92,7 @@ namespace MbDotNet.Models.Stubs
 		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public TcpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
-			IList<MatchesPredicate<TcpPredicateFields>> predicateGenerators)
+			IEnumerable<MatchesPredicate<TcpPredicateFields>> predicateGenerators)
 		{
 			var fields = new ProxyResponseFields<TcpPredicateFields>
 			{
@@ -114,7 +114,7 @@ namespace MbDotNet.Models.Stubs
 		/// <param name="predicateGenerators">list of predicates that a proxy repsonse will be recorded for</param>
 		/// <returns>The stub that the response was added to</returns>
 		public TcpStub ReturnsProxy(Uri to, ProxyMode proxyMode,
-			IList<MatchesPredicate<TcpBooleanPredicateFields>> predicateGenerators)
+			IEnumerable<MatchesPredicate<TcpBooleanPredicateFields>> predicateGenerators)
 		{
 			var fields = new ProxyResponseFields<TcpBooleanPredicateFields>
 			{

--- a/MbDotNet/MountebankClient.cs
+++ b/MbDotNet/MountebankClient.cs
@@ -160,17 +160,17 @@ namespace MbDotNet
 		}
 
 		/// <inheritdoc />
-		public async Task ReplaceHttpImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs,
+		public async Task ReplaceHttpImposterStubsAsync(int port, IEnumerable<HttpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
 			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
-		public async Task ReplaceHttpsImposterStubsAsync(int port, ICollection<HttpStub> replacementStubs,
+		public async Task ReplaceHttpsImposterStubsAsync(int port, IEnumerable<HttpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
 			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 
 		/// <inheritdoc />
-		public async Task ReplaceTcpImposterStubsAsync(int port, ICollection<TcpStub> replacementStubs,
+		public async Task ReplaceTcpImposterStubsAsync(int port, IEnumerable<TcpStub> replacementStubs,
 			CancellationToken cancellationToken = default) =>
 			await _requestProxy.ReplaceStubsAsync(port, replacementStubs, cancellationToken).ConfigureAwait(false);
 

--- a/MbDotNet/MountebankRequestProxy.cs
+++ b/MbDotNet/MountebankRequestProxy.cs
@@ -68,7 +68,7 @@ namespace MbDotNet
 			}
 		}
 
-		public async Task ReplaceStubsAsync<T>(int port, ICollection<T> replacementStubs,
+		public async Task ReplaceStubsAsync<T>(int port, IEnumerable<T> replacementStubs,
 			CancellationToken cancellationToken = default) where T: Stub
 		{
 			var json = JsonConvert.SerializeObject(new


### PR DESCRIPTION
Various collection types were being used inconsistently. This is an attempt to make their usage more consistent.

Arguments -> `IEnumerable`
Models that should be modifiable -> `IList`
Models returned from Mountebank -> `IReadOnlyList`
Binary data returned from Mountebank -> array