### PR TITLE
Upgrade .NET versions

### DIFF
--- a/MbDotNet.Tests/MbDotNet.Tests.csproj
+++ b/MbDotNet.Tests/MbDotNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MbDotNetKey.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/MbDotNet/MbDotNet.csproj
+++ b/MbDotNet/MbDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>MbDotNetKey.snk</AssemblyOriginatorKeyFile>
     <!-- This is necessary until full signing is available on non-windows platforms -->
@@ -31,7 +31,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The library is available for install as a NuGet package.
 
 https://www.nuget.org/packages/MbDotNet
 
-The project currently targets .NET Standard 1.3, which is compatible with .NET Framework 4.6. If you need to use it in a project targeting an older framework version, such as .NET Framework 4.5, please use version 3.x of the package.
+The project currently targets .NET Standard 2.0, which is compatible with .NET Framework 4.6.1+. If you need to use it in a project targeting an older framework version, such as .NET Framework 4.5, please use version 3.x of the package.
 
 ## Upgrading from v4 (or earlier) to v5
 
@@ -46,7 +46,7 @@ Pull requests are always welcome.
 
 The following items are necessary in order to build and test the project:
 
-- .NET SDK 6.0
+- .NET SDK 10.0
 - Mountebank or Docker Compose
 
 ### Building


### PR DESCRIPTION
* Updating test project to latest LTS .NET 10 (from .NET 6).
* Updating library to .NET Standard 2.0 (from .NET Standard 1.3) - this will remove support for .NET Framework 4.6.0 and below. This also allowed the removal of the `System.Xml.XmlSerializer` dependency.